### PR TITLE
OPENEUROPA-769: Use openeuropa/drupal-core-require-dev

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         "drush/drush": "^9",
         "nikic/php-parser": "~3",
         "openeuropa/code-review": "~0.2",
-        "openeuropa/drupal-core-require-dev": "~8.6",
+        "openeuropa/drupal-core-require-dev": "~8.6@alpha",
         "openeuropa/task-runner": "~0.7"
     },
     "scripts": {


### PR DESCRIPTION
## OPENEUROPA-769

### Description

Update version of dev requirement in composer.

### Change log

Make the versions compatibles



