### PR TITLE
OPENEUROPA-164: Authentication: fix login error on ECAS redirect

### DIFF
--- a/src/UserProvider.php
+++ b/src/UserProvider.php
@@ -82,11 +82,12 @@ class UserProvider {
    * @throws \Exception
    */
   protected function doLoadAccount(PCasUserInterface $pCasUser) {
-    $mail = $pCasUser->get('cas:email');
-    if (empty($mail)) {
-      throw new \Exception('Email address not provided by OE Authentication.');
+    $username = $pCasUser->get('cas:user');
+    if (!$username) {
+      throw new \Exception('No username found on the PCas user.');
     }
-    $accounts = $this->userStorage->loadByProperties(['mail' => $mail]);
+
+    $accounts = $this->userStorage->loadByProperties(['name' => $username]);
     if (empty($accounts)) {
       // Account does not exist, creation of new accounts is handled in.
       // @see \Drupal\oe_authentication\Controller\OeAuthenticationController::login.
@@ -107,6 +108,7 @@ class UserProvider {
    */
   protected function createAccount(PCasUserInterface $pCasUser) {
     $name = $this->uniqueUsername($pCasUser->getUsername());
+    // @todo Fix the retrieval of the email as not all CAS replies have "cas:email".
     $mail = $pCasUser->get('cas:email');
 
     /** @var \Drupal\user\Entity\User $account */

--- a/src/UserProvider.php
+++ b/src/UserProvider.php
@@ -83,7 +83,7 @@ class UserProvider {
    */
   protected function doLoadAccount(PCasUserInterface $pCasUser) {
     $username = $pCasUser->get('cas:user');
-    if (!$username) {
+    if ($username === NULL) {
       throw new \Exception('No username found on the PCas user.');
     }
 


### PR DESCRIPTION
## OPENEUROPA-164

### Description

The problem here is that the CAS response from ECAS does not contain the user email in the assumed `cas:email` key of the XML. The `demo-server` of the PCas library does. 

This PR fixes the error by looking for the user based on the user name found in the `cas:user` key which is part of a standard [CAS response](https://apereo.github.io/cas/5.1.x/protocol/CAS-Protocol-Specification.html#252-response) for ticket validation.

In a follow up we need to ensure that retrieving the email is done for both ECAS and the demo-server.

### Change log

- Added:
- Changed:
- Deprecated:
- Removed:
- Fixed:
- Security:

### Commands

```sh
[Insert commands here]

```

