### PR TITLE
OPENEUROPA-1177: Consolidate oe_authentication

### DIFF
--- a/oe_authentication.module
+++ b/oe_authentication.module
@@ -2,7 +2,7 @@
 
 /**
  * @file
- * OpenEuropa Webtools Laco Widget module.
+ * OpenEuropa Authentication module.
  */
 
 declare(strict_types = 1);

--- a/oe_authentication.module
+++ b/oe_authentication.module
@@ -13,8 +13,8 @@ use Drupal\Core\Form\FormStateInterface;
  * Implements hook_form_alter().
  */
 function oe_authentication_form_user_form_alter(&$form, FormStateInterface $form_state, $form_id) {
-    $form['account']['mail']['#disabled'] = TRUE;
-    $form['account']['name']['#disabled'] = TRUE;
-    unset($form['account']['pass']);
-    unset($form['account']['current_pass']);
+  $form['account']['mail']['#disabled'] = TRUE;
+  $form['account']['name']['#disabled'] = TRUE;
+  unset($form['account']['pass']);
+  unset($form['account']['current_pass']);
 }

--- a/oe_authentication.module
+++ b/oe_authentication.module
@@ -1,0 +1,20 @@
+<?php
+
+/**
+ * @file
+ * OpenEuropa Webtools Laco Widget module.
+ */
+
+declare(strict_types = 1);
+
+use Drupal\Core\Form\FormStateInterface;
+
+/**
+ * Implements hook_form_alter().
+ */
+function oe_authentication_form_user_form_alter(&$form, FormStateInterface $form_state, $form_id) {
+    $form['account']['mail']['#disabled'] = TRUE;
+    $form['account']['name']['#disabled'] = TRUE;
+    unset($form['account']['pass']);
+    unset($form['account']['current_pass']);
+}

--- a/oe_authentication.services.yml
+++ b/oe_authentication.services.yml
@@ -2,7 +2,7 @@ parameters:
   oe_authentication.pcas.base_url: ~
 services:
   oe_authentication.authentication:
-    class: \Drupal\oe_authentication\Authentication\Provider\OeAuthentication
+    class: \Drupal\oe_authentication\Authentication\Provider\Authentication
     arguments: ['@oe_authentication.pcas.factory', '@oe_authentication.user_provider']
     tags:
       - { name: authentication_provider, provider_id: 'oe_authentication', priority: -10, global: TRUE }

--- a/src/Authentication/Provider/Authentication.php
+++ b/src/Authentication/Provider/Authentication.php
@@ -12,7 +12,7 @@ use Symfony\Component\HttpFoundation\Request;
 /**
  * Cookie based authentication provider.
  */
-class OeAuthentication implements AuthenticationProviderInterface {
+class Authentication implements AuthenticationProviderInterface {
 
   /**
    * The pCas variable.
@@ -29,7 +29,7 @@ class OeAuthentication implements AuthenticationProviderInterface {
   protected $userProvider;
 
   /**
-   * OeAuthentication constructor.
+   * Authentication constructor.
    *
    * @param \Drupal\oe_authentication\PCasFactory $pCasFactory
    *   The pCas variable.

--- a/src/Controller/AuthenticationController.php
+++ b/src/Controller/AuthenticationController.php
@@ -14,7 +14,7 @@ use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
 /**
  * Returns responses for OE Authentication routes.
  */
-class OeAuthenticationController extends ControllerBase {
+class AuthenticationController extends ControllerBase {
 
   /**
    * The request stack.

--- a/src/Exception/AuthenticationException.php
+++ b/src/Exception/AuthenticationException.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Drupal\oe_authentication\Exception;
+
+/**
+ * Base class for the Open Europa Authentication exceptions.
+ */
+class AuthenticationException extends \Exception {}

--- a/src/Routing/RouteSubscriber.php
+++ b/src/Routing/RouteSubscriber.php
@@ -20,13 +20,13 @@ class RouteSubscriber extends RouteSubscriberBase {
     if ($route = $collection->get('user.login')) {
       $defaults = $route->getDefaults();
       unset($defaults['_form']);
-      $defaults['_controller'] = '\Drupal\oe_authentication\Controller\OeAuthenticationController::login';
+      $defaults['_controller'] = '\Drupal\oe_authentication\Controller\AuthenticationController::login';
       $route->setDefaults($defaults);
     }
 
     // Replace the core logout route.
     if ($route = $collection->get('user.logout')) {
-      $route->setDefault('_controller', '\Drupal\oe_authentication\Controller\OeAuthenticationController::logout');
+      $route->setDefault('_controller', '\Drupal\oe_authentication\Controller\AuthenticationController::logout');
     }
     // Remove these routes as to generate fatal errors wherever
     // functionality is missing.

--- a/src/Routing/RouteSubscriber.php
+++ b/src/Routing/RouteSubscriber.php
@@ -46,7 +46,7 @@ class RouteSubscriber extends RouteSubscriberBase {
     ];
     foreach ($routes_to_remove as $route_to_remove) {
       if ($route = $collection->get($route_to_remove)) {
-        $collection->remove($route_to_remove);
+        $route->setRequirement('_access', 'FALSE');
       }
     }
   }

--- a/src/UserProvider.php
+++ b/src/UserProvider.php
@@ -90,7 +90,7 @@ class UserProvider {
     $accounts = $this->userStorage->loadByProperties(['name' => $username]);
     if (empty($accounts)) {
       // Account does not exist, creation of new accounts is handled in.
-      // @see \Drupal\oe_authentication\Controller\OeAuthenticationController::login.
+      // @see \Drupal\oe_authentication\Controller\AuthenticationController::login.
       return FALSE;
     }
 

--- a/src/UserProvider.php
+++ b/src/UserProvider.php
@@ -5,6 +5,7 @@ declare(strict_types = 1);
 namespace Drupal\oe_authentication;
 
 use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\oe_authentication\Exception\AuthenticationException;
 use Drupal\user\UserInterface;
 use OpenEuropa\pcas\Security\Core\User\PCasUserInterface;
 
@@ -84,7 +85,7 @@ class UserProvider {
   protected function doLoadAccount(PCasUserInterface $pCasUser) {
     $username = $pCasUser->get('cas:user');
     if ($username === NULL) {
-      throw new \Exception('No username found on the PCas user.');
+      throw new AuthenticationException('No username found on the PCas user.');
     }
 
     $accounts = $this->userStorage->loadByProperties(['name' => $username]);
@@ -108,8 +109,7 @@ class UserProvider {
    */
   protected function createAccount(PCasUserInterface $pCasUser) {
     $name = $this->uniqueUsername($pCasUser->getUsername());
-    // @todo Fix the retrieval of the email as not all CAS replies have "cas:email".
-    $mail = $pCasUser->get('cas:email');
+    $mail = $this->extractEmailFromCasUser($pCasUser);
 
     /** @var \Drupal\user\Entity\User $account */
     $account = $this->userStorage->create([
@@ -156,6 +156,39 @@ class UserProvider {
   protected function canCreateNewAccounts() {
     // @todo Implement this stub with a setting?
     return TRUE;
+  }
+
+  /**
+   * Extracts the email address from a PCas user object.
+   *
+   * Since CAS implementations return differently the user information,
+   * we need to extract the email value generically.
+   *
+   * @todo Refactor and bring logic for user value retrieval to PCas library
+   *   using configuration.
+   *
+   * @param \OpenEuropa\pcas\Security\Core\User\PCasUserInterface $pCasUser
+   *   The PCas user object.
+   *
+   * @return string
+   *   The email address.
+   */
+  protected function extractEmailFromCasUser(PCasUserInterface $pCasUser): string {
+    if ($pCasUser->get('cas:email') !== NULL) {
+      return $pCasUser->get('cas:email');
+    }
+
+    // ECAS.
+    if ($pCasUser->get('cas:authenticationFactors') !== NULL) {
+      $authentication_factors = $pCasUser->get('cas:authenticationFactors');
+      if (isset($authentication_factors['cas:moniker'])) {
+        return $authentication_factors['cas:moniker'];
+      }
+
+      throw new AuthenticationException('ECAS user email address is missing.');
+    }
+
+    throw new AuthenticationException('Could not determine user email from PCas response.');
   }
 
 }

--- a/src/UserProvider.php
+++ b/src/UserProvider.php
@@ -180,9 +180,9 @@ class UserProvider {
 
     // ECAS.
     if ($pCasUser->get('cas:authenticationFactors') !== NULL) {
-      $authentication_factors = $pCasUser->get('cas:authenticationFactors');
-      if (isset($authentication_factors['cas:moniker'])) {
-        return $authentication_factors['cas:moniker'];
+      $auth_factors = $pCasUser->get('cas:authenticationFactors');
+      if (isset($auth_factors['cas:moniker'])) {
+        return $auth_factors['cas:moniker'];
       }
 
       throw new AuthenticationException('ECAS user email address is missing.');

--- a/tests/Kernel/PCasFactoryTest.php
+++ b/tests/Kernel/PCasFactoryTest.php
@@ -55,7 +55,7 @@ class PCasFactoryTest extends KernelTestBase {
    * Test custom configuration options for the PCasFactory class.
    */
   public function testCustomConfiguration(): void {
-    $this->config("oe_authentication.settings")
+    $this->config('oe_authentication.settings')
       ->set('base_url', 'https://ecas.ec.europa.eu/cas')
       ->save(TRUE);
     $protocols = [

--- a/tests/Kernel/PCasFactoryTest.php
+++ b/tests/Kernel/PCasFactoryTest.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types = 1);
+
+
+namespace Drupal\Tests\oe_authentication\Kernel;
+
+use Drupal\KernelTests\KernelTestBase;
+use Drupal\oe_authentication\PCasFactory;
+
+/**
+ * Class InstallationTest.
+ */
+class PCasFactoryTest extends KernelTestBase {
+
+  /**
+   * Modules to enable.
+   *
+   * @var array
+   */
+  public static $modules = [
+    'oe_authentication',
+    'system',
+    'user',
+  ];
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp() {
+    parent::setUp();
+
+    $this->installConfig([
+      'oe_authentication',
+    ]);
+  }
+
+  /**
+   * Test default configuration options for the PCasFactory class.
+   */
+  public function testDefaultConfiguration(): void {
+    $pcasfactory = new PCasFactory($this->container->get('session'), $this->container->get('config.factory'));
+    $pcas = $pcasfactory->getPCas();
+    $properties = $pcas->getProperties();
+    $this->assertEquals('http://authentication:8001', $properties['base_url']);
+    $login_protocol = [
+      'path' => '/login',
+      'query' => [],
+      'allowed_parameters' => ['service', 'renew', 'gateway'],
+    ];
+    $this->assertEquals($login_protocol, $properties['protocol']['login']);
+  }
+
+  /**
+   * Test custom configuration options for the PCasFactory class.
+   */
+  public function testCustomConfiguration(): void {
+    $this->config("oe_authentication.settings")
+      ->set('base_url', 'https://ecas.ec.europa.eu/cas')
+      ->save(TRUE);
+    $protocols = [
+      'login' => [
+        'path' => '/login',
+        'query' => [],
+        'allowed_parameters' => ['service', 'renew', 'gateway'],
+      ],
+    ];
+    $pcasfactory = new PCasFactory($this->container->get('session'), $this->container->get('config.factory'), $protocols);
+    $pcas = $pcasfactory->getPCas();
+    $properties = $pcas->getProperties();
+    $this->assertEquals('https://ecas.ec.europa.eu/cas', $properties['base_url']);
+    $this->assertEquals($protocols, $properties['protocol']);
+  }
+
+}


### PR DESCRIPTION
## OPENEUROPA-1177

### Description

Consolidate the oe_authentication Drupal module and its integration with ECAS.

UPDATE: As agreed, we will merge what we had and continue on two other tracks while what we have so far stays in 0.x:

* 1.x - Using the Drupal CAS module
* 2.x - Abstracting the authentication layer to use other authentication systems as well.

### Change log

- Added:
- Changed:
- Deprecated:
- Removed:
- Fixed:
- Security:

### Commands

```sh
[Insert commands here]

```

