### PR TITLE
OPENEUROPA-784: Make sure component dependencies are as relaxed as possible.

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -15,13 +15,30 @@ services:
     image: openeuropa/pcas-server:latest
 
 pipeline:
-  composer-install:
+  composer-install-lowest:
     group: prepare
     image: fpfis/httpd-php-dev:7.1
     volumes:
       - /cache:/cache
     commands:
-      - composer install
+    # @todo remove "composer install" step once the following issue is fixed.
+    # @link https://webgate.ec.europa.eu/CITnet/jira/browse/OPENEUROPA-1234
+    - composer install --ansi --no-suggest --no-progress
+    - composer update --prefer-lowest --prefer-stable --ansi --no-suggest --no-progress
+    when:
+      matrix:
+        COMPOSER_BOUNDARY: lowest
+
+  composer-install-highest:
+    group: prepare
+    image: fpfis/httpd-php-dev:7.1
+    volumes:
+    - /cache:/cache
+    commands:
+    - composer install --ansi --no-suggest --no-progress
+    when:
+      matrix:
+        COMPOSER_BOUNDARY: highest
 
   site-install:
     image: fpfis/httpd-php-dev:7.1
@@ -48,3 +65,8 @@ pipeline:
       - ./vendor/bin/drush -y config-set system.performance css.preprocess 0
       - ./vendor/bin/drush -y config-set system.performance js.preprocess 0
       - ./vendor/bin/behat
+
+matrix:
+  COMPOSER_BOUNDARY:
+  - lowest
+  - highest

--- a/.drone.yml
+++ b/.drone.yml
@@ -23,7 +23,8 @@ pipeline:
     commands:
     # @todo remove "composer install" step once the following issue is fixed.
     # @link https://webgate.ec.europa.eu/CITnet/jira/browse/OPENEUROPA-1234
-    - composer install --ansi --no-suggest --no-progress
+    # @note COMPOSER_ROOT_VERSION , see https://getcomposer.org/doc/articles/troubleshooting.md#package-not-found-on-travis-ci-org
+    - COMPOSER_ROOT_VERSION=dev-${DRONE_BRANCH} composer install --ansi --no-suggest --no-progress
     - composer update --prefer-lowest --prefer-stable --ansi --no-suggest --no-progress
     when:
       matrix:
@@ -35,7 +36,7 @@ pipeline:
     volumes:
     - /cache:/cache
     commands:
-    - composer install --ansi --no-suggest --no-progress
+    - COMPOSER_ROOT_VERSION=dev-${DRONE_BRANCH} composer install --ansi --no-suggest --no-progress
     when:
       matrix:
         COMPOSER_BOUNDARY: highest

--- a/.drone.yml
+++ b/.drone.yml
@@ -23,8 +23,7 @@ pipeline:
     commands:
     # @todo remove "composer install" step once the following issue is fixed.
     # @link https://webgate.ec.europa.eu/CITnet/jira/browse/OPENEUROPA-1234
-    # @note COMPOSER_ROOT_VERSION , see https://getcomposer.org/doc/articles/troubleshooting.md#package-not-found-on-travis-ci-org
-    - COMPOSER_ROOT_VERSION=dev-${DRONE_BRANCH} composer install --ansi --no-suggest --no-progress
+    - composer install --ansi --no-suggest --no-progress
     - composer update --prefer-lowest --prefer-stable --ansi --no-suggest --no-progress
     when:
       matrix:
@@ -36,7 +35,7 @@ pipeline:
     volumes:
     - /cache:/cache
     commands:
-    - COMPOSER_ROOT_VERSION=dev-${DRONE_BRANCH} composer install --ansi --no-suggest --no-progress
+    - composer install --ansi --no-suggest --no-progress
     when:
       matrix:
         COMPOSER_BOUNDARY: highest

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # OpenEuropa Authentication
 
 [![Build Status](https://drone.fpfis.eu/api/badges/openeuropa/oe_authentication/status.svg?branch=master)](https://drone.fpfis.eu/openeuropa/oe_authentication)
+[![Packagist](https://img.shields.io/packagist/v/openeuropa/oe_authentication.svg)](https://packagist.org/packages/openeuropa/oe_authentication)
 
 The OpenEuropa Authentication module allows to authenticate against EU Login, the European Commission login service.
 

--- a/composer.json
+++ b/composer.json
@@ -21,6 +21,7 @@
         "openeuropa/code-review": "^1.0.0-alpha4",
         "openeuropa/drupal-core-require-dev": "^8.6",
         "openeuropa/task-runner": "~1.0",
+        "phpunit/phpunit": "~6.0",
         "symfony/browser-kit": "~3.0||~4.0"
     },
     "scripts": {

--- a/composer.json
+++ b/composer.json
@@ -8,20 +8,20 @@
     "require": {
         "php": "^7.1",
         "drupal/cas": "^1.0",
-        "drupal/core": "~8.6@alpha"
+        "drupal/core": "^8.6"
     },
     "require-dev": {
-        "composer/installers": "^1.2",
-        "cweagans/composer-patches": "~1.0",
-        "drupal-composer/drupal-scaffold": "^2.2",
+        "composer/installers": "~1.5",
+        "drupal-composer/drupal-scaffold": "~2.2",
         "drupal/config_devel": "~1.2",
-        "drupal/console": "^1.6",
-        "drupal/drupal-extension": "^4.0.0@alpha",
-        "drush/drush": "^9",
-        "nikic/php-parser": "~3",
-        "openeuropa/code-review": "~0.2",
-        "openeuropa/drupal-core-require-dev": "~8.6",
-        "openeuropa/task-runner": "~0.7"
+        "drupal/console": "~1.0",
+        "drupal/drupal-extension": "^4.0.0@beta",
+        "drush/drush": "~9.4",
+        "nikic/php-parser": "~3.0",
+        "openeuropa/code-review": "^1.0.0-alpha4",
+        "openeuropa/drupal-core-require-dev": "8.6.x-dev",
+        "openeuropa/task-runner": "~1.0",
+        "symfony/browser-kit": "~3.0||~4.0"
     },
     "scripts": {
         "drupal-scaffold": "DrupalComposer\\DrupalScaffold\\Plugin::scaffold",
@@ -54,11 +54,11 @@
             "build/themes/contrib/{$name}": ["type:drupal-theme"]
         },
         "patches": {
-          "drupal/cas": {
-            "Add support for http CAS servers": "https://www.drupal.org/files/issues/2018-09-03/2996924-4.patch",
-            "Provide custom mail handlers": "https://www.drupal.org/files/issues/2018-09-04/2996955-2.patch",
-            "Provide after validation event": "https://www.drupal.org/files/issues/2018-09-05/2997099-4.patch"
-          }
+            "drupal/cas": {
+                "Add support for http CAS servers": "https://www.drupal.org/files/issues/2018-09-03/2996924-4.patch",
+                "Provide custom mail handlers": "https://www.drupal.org/files/issues/2018-09-04/2996955-2.patch",
+                "Provide after validation event": "https://www.drupal.org/files/issues/2018-09-05/2997099-4.patch"
+            }
         }
     },
     "config": {

--- a/composer.json
+++ b/composer.json
@@ -16,10 +16,10 @@
         "drupal/config_devel": "~1.2",
         "drupal/console": "~1.0",
         "drupal/drupal-extension": "^4.0.0@beta",
-        "drush/drush": "~9.4",
+        "drush/drush": "~9.0@stable",
         "nikic/php-parser": "~3.0",
         "openeuropa/code-review": "^1.0.0-alpha4",
-        "openeuropa/drupal-core-require-dev": "8.6.x-dev",
+        "openeuropa/drupal-core-require-dev": "^8.6",
         "openeuropa/task-runner": "~1.0",
         "symfony/browser-kit": "~3.0||~4.0"
     },


### PR DESCRIPTION
Components dependencies:

  - Update some version to use tilde, so it uses the minimal minor version and also for a consistency use decimal number as the version.

  - Update some packages to use minimal minor version.

  - Added composer boundary to test lowest and highest.

 - Added packagist badge.