### PR TITLE
OPENEUROPA-1209: Change settings for CAS and module

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,22 +21,9 @@ The recommended way of installing the OpenEuropa Authentication module is via a 
 composer require openeuropa/oe_authentication
 ```
 
-Before being able to use the module, you will need to specify the EuLogin service parameters
-in your Drupal installation's `./sites/default/settings.php` file as shown below:
+EuLogin service parameters are already set by default.
 
-```
-$config['cas.settings']['server']['hostname'] = 'ecas.ec.europa.eu';
-$config['cas.settings']['server']['port'] = NULL;
-$config['cas.settings']['server']['path'] = '/cas';
-$config['cas.settings']['server']['protocol'] = 'https';
-```
-
-In addition, in order to use EuLogin based servers you will need to you will need to define the following parameters:
-```
-$config['oe_authentication.settings']['validation_path'] = 'ticketValidation';
-$config['oe_authentication.settings']['assurance_level'] = 'LOW';
-$config['oe_authentication.settings']['ticket_types'] = 'SERVICE';
-```
+You can see Project setup section how to oeveride these parameters.
 Please refer to the EuLogin documentation for more available options for those parameters.
 
 For more information about how to override service parameters in Drupal 8
@@ -83,8 +70,27 @@ $ ./vendor/bin/run drupal:site-setup
 This will:
 
 - Symlink the theme in  `./build/modules/custom/oe_authentication` so that it's available for the test site
-- Setup Drush and Drupal's settings using values from `./runner.yml.dist`
+- Setup Drush and Drupal's settings using values from `./runner.yml.dist`. This includes adding parameters for EULogin
 - Setup PHPUnit and Behat configuration files using values from `./runner.yml.dist`
+
+Drupal's settings override the default EuLogin service parameters
+in Drupal installation's `./sites/default/settings.php` file as shown below:
+
+```
+$config['cas.settings']['server']['hostname'] = 'authentication';
+$config['cas.settings']['server']['port'] = '8001';
+$config['cas.settings']['server']['path'] = '/';
+$config['cas.settings']['server']['protocol'] = 'http';
+```
+
+In addition, in order to use EuLogin based servers it overrides the following parameters:
+```
+$config['oe_authentication.settings']['validation_path'] = 'ticketValidation';
+$config['oe_authentication.settings']['assurance_level'] = 'LOW';
+$config['oe_authentication.settings']['ticket_types'] = 'SERVICE';
+```
+
+You can override later here all CAS and OpenEuropa Authentication settings.
 
 After a successful setup install the site by running:
 

--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ $config['cas.settings']['server']['protocol'] = 'http';
 
 In addition, in order to use EuLogin based servers it overrides the following parameters:
 ```
+$config['oe_authentication.settings']['register_path'] = 'register';
 $config['oe_authentication.settings']['validation_path'] = 'ticketValidation';
 $config['oe_authentication.settings']['assurance_level'] = 'LOW';
 $config['oe_authentication.settings']['ticket_types'] = 'SERVICE';

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ This will:
 - Setup Drush and Drupal's settings using values from `./runner.yml.dist`. This includes adding parameters for EULogin
 - Setup PHPUnit and Behat configuration files using values from `./runner.yml.dist`
 
-Drupal's settings override the default EuLogin service parameters
+Drupal's settings overrides the default EuLogin service parameters
 in Drupal installation's `./sites/default/settings.php` file as shown below:
 
 ```
@@ -91,7 +91,7 @@ $config['oe_authentication.settings']['assurance_level'] = 'LOW';
 $config['oe_authentication.settings']['ticket_types'] = 'SERVICE';
 ```
 
-You can override later here all CAS and OpenEuropa Authentication settings.
+This way, it's possible to override here all CAS and OpenEuropa Authentication settings.
 
 After a successful setup install the site by running:
 

--- a/README.md
+++ b/README.md
@@ -15,19 +15,11 @@ The OpenEuropa Authentication module allows to authenticate against the European
 
 ## Installation
 
-The recommended way of installing the OpenEuropa Authentication module is via a [Composer][2].
+The recommended way of installing the OpenEuropa Authentication module is via [Composer][2].
 
 ```bash
 composer require openeuropa/oe_authentication
 ```
-
-EuLogin service parameters are already set by default.
-
-You can see Project setup section how to oeveride these parameters.
-Please refer to the EuLogin documentation for more available options for those parameters.
-
-For more information about how to override service parameters in Drupal 8
-check the [related documentation page](https://www.drupal.org/docs/8/api/services-and-dependency-injection/services-and-dependency-injection-in-drupal-8)
 
 ### Enable the module
 
@@ -36,6 +28,9 @@ In order to enable the module in your project run:
 ```
 $ ./vendor/bin/drush en oe_authentication
 ```
+
+EU Login service parameters are already set by default when installing the module. Please refer to the EU Login documentation for the available options that can
+be specified. You can see Project setup section on how to override these parameters.
 
 ## Development
 
@@ -73,26 +68,6 @@ This will:
 - Setup Drush and Drupal's settings using values from `./runner.yml.dist`. This includes adding parameters for EULogin
 - Setup PHPUnit and Behat configuration files using values from `./runner.yml.dist`
 
-Drupal's settings overrides the default EuLogin service parameters
-in Drupal installation's `./sites/default/settings.php` file as shown below:
-
-```
-$config['cas.settings']['server']['hostname'] = 'authentication';
-$config['cas.settings']['server']['port'] = '8001';
-$config['cas.settings']['server']['path'] = '/';
-$config['cas.settings']['server']['protocol'] = 'http';
-```
-
-In addition, in order to use EuLogin based servers it overrides the following parameters:
-```
-$config['oe_authentication.settings']['register_path'] = 'register';
-$config['oe_authentication.settings']['validation_path'] = 'ticketValidation';
-$config['oe_authentication.settings']['assurance_level'] = 'LOW';
-$config['oe_authentication.settings']['ticket_types'] = 'SERVICE';
-```
-
-This way, it's possible to override here all CAS and OpenEuropa Authentication settings.
-
 After a successful setup install the site by running:
 
 ```
@@ -104,10 +79,30 @@ This will:
 - Install the test site
 - Enable the OpenEuropa Authentication module
 
-Then setup the mock servers dependencies by running:
+#### Settings overrides
+
+In the Drupal `settings.php` you can override CAS parameters such as the ones below, corresponding to the
+`cas.settings` and `oe_authentication.settings` configuration objects.
+
 ```
-$ ./vendor/bin/composer --no-ansi --working-dir=/var/www/html/vendor/openeuropa/pcas/demo-server/ install
+$config['cas.settings']['server']['hostname'] = 'authentication';
+$config['cas.settings']['server']['port'] = '8001';
+$config['cas.settings']['server']['path'] = '/';
+$config['cas.settings']['server']['protocol'] = 'http';
 ```
+
+```
+$config['oe_authentication.settings']['register_path'] = 'register';
+$config['oe_authentication.settings']['validation_path'] = 'ticketValidation';
+$config['oe_authentication.settings']['assurance_level'] = 'LOW';
+$config['oe_authentication.settings']['ticket_types'] = 'SERVICE';
+```
+
+By default, the development setup is configured via te Task Runner to use the demo CAS server provided in the
+`docker-compose.yml.dist`, i.e. `http://authentication:8001`.
+
+If you want to test the module with the actual EU Login service, comment out the `$config['cas.settings']...` lines in
+your `settings.php` and clear the cache.
 
 ### Using Docker Compose
 

--- a/config/install/oe_authentication.settings.yml
+++ b/config/install/oe_authentication.settings.yml
@@ -1,3 +1,3 @@
-validation_path: ''
-assurance_level: LOW
-ticket_types: SERVICE
+validation_path: 'ticketValidation'
+assurance_level: TOP
+ticket_types: SERVICE,PROXY

--- a/oe_authentication.install
+++ b/oe_authentication.install
@@ -14,16 +14,17 @@ function oe_authentication_install() {
 
   // Set default settings for CAS.
   \Drupal::configFactory()->getEditable('cas.settings')
-    ->set('server.protocol', 'http')
-    ->set('server.hostname', 'authentication')
-    ->set('server.port', '8001')
-    ->set('server.path', '/')
+    ->set('server.hostname', 'ecas.ec.europa.eu')
+    ->set('server.path', '/cas')
     ->set('forced_login.enabled', TRUE)
     ->set('forced_login.paths.pages', '/user/login')
+    ->set('logout.cas_logout', TRUE)
+    ->set('logout.logout_destination', '<front>')
     ->set('user_accounts.prevent_normal_login', TRUE)
     ->set('user_accounts.auto_register', TRUE)
-    ->set('login_link_enabled', TRUE)
     ->set('user_accounts.restrict_password_management', TRUE)
     ->set('user_accounts.restrict_email_management', TRUE)
+    ->set('user_accounts.email_hostname', 'disabled')
+    ->set('login_link_enabled', TRUE)
     ->save();
 }

--- a/runner.yml.dist
+++ b/runner.yml.dist
@@ -23,6 +23,11 @@ drupal:
         - "${drupal.root}"
       container_yamls:
         - "${runner.working_dir}/build/site/default/services.yml"
+    config:
+     oe_authentication.settings:
+       validation_path: "ticketValidation"
+       assurance_level: "LOW"
+       ticket_types: "SERVICE"
 
 commands:
   drupal:site-setup:
@@ -31,6 +36,9 @@ commands:
     - { task: "symlink", from: "../../..", to: "${drupal.root}/modules/custom/oe_authentication" }
     - { task: "run", command: "drupal:drush-setup" }
     - { task: "run", command: "drupal:settings-setup" }
+    - task: "append"
+      file: "build/sites/default/default.settings.php"
+      text: "\n$config['cas.settings']['server']['protocol'] = 'http';\n$config['cas.settings']['server']['hostname'] = 'authentication';\n$config['cas.settings']['server']['port'] = '8001';\n$config['cas.settings']['server']['path'] = '/';\n"
     - { task: "run", command: "setup:phpunit" }
     - { task: "run", command: "setup:behat" }
   setup:phpunit:

--- a/runner.yml.dist
+++ b/runner.yml.dist
@@ -26,9 +26,7 @@ drupal:
     config:
      oe_authentication.settings:
        register_path: "register"
-       validation_path: "ticketValidation"
-       assurance_level: "LOW"
-       ticket_types: "SERVICE"
+       validation_path: "serviceValidate"
 
 commands:
   drupal:site-setup:
@@ -36,10 +34,10 @@ commands:
     - { task: "mkdir", dir: "${drupal.root}/themes" }
     - { task: "symlink", from: "../../..", to: "${drupal.root}/modules/custom/oe_authentication" }
     - { task: "run", command: "drupal:drush-setup" }
-    - { task: "run", command: "drupal:settings-setup" }
     - task: "append"
       file: "build/sites/default/default.settings.php"
       text: "\n$config['cas.settings']['server']['protocol'] = 'http';\n$config['cas.settings']['server']['hostname'] = 'authentication';\n$config['cas.settings']['server']['port'] = '8001';\n$config['cas.settings']['server']['path'] = '/';\n"
+    - { task: "run", command: "drupal:settings-setup" }
     - { task: "run", command: "setup:phpunit" }
     - { task: "run", command: "setup:behat" }
   setup:phpunit:

--- a/runner.yml.dist
+++ b/runner.yml.dist
@@ -25,6 +25,7 @@ drupal:
         - "${runner.working_dir}/build/site/default/services.yml"
     config:
      oe_authentication.settings:
+       register_path: "register"
        validation_path: "ticketValidation"
        assurance_level: "LOW"
        ticket_types: "SERVICE"

--- a/src/Event/EuLoginEventSubscriber.php
+++ b/src/Event/EuLoginEventSubscriber.php
@@ -13,7 +13,7 @@ use Symfony\Component\EventDispatcher\EventSubscriberInterface;
  * Event subscriber for CAS module events.
  *
  * The class subscribes to the events provided by the CAS module and makes
- * the required modifications to work with EuLogin.
+ * the required modifications to work with EU Login.
  */
 class EuLoginEventSubscriber implements EventSubscriberInterface {
 
@@ -31,7 +31,7 @@ class EuLoginEventSubscriber implements EventSubscriberInterface {
   }
 
   /**
-   * Generates the user email based on the information taken from EuLogin.
+   * Generates the user email based on the information taken from EU Login.
    *
    * @param \Drupal\cas\Event\CasPreRegisterEvent $event
    *   The triggered event.
@@ -51,7 +51,7 @@ class EuLoginEventSubscriber implements EventSubscriberInterface {
   }
 
   /**
-   * Parses the EuLogin attributes from the validation response.
+   * Parses the EU Login attributes from the validation response.
    *
    * @param \Drupal\cas\Event\CasAfterValidateEvent $event
    *   The triggered event.
@@ -85,7 +85,7 @@ class EuLoginEventSubscriber implements EventSubscriberInterface {
   }
 
   /**
-   * Parse the attributes list from the EuLogin Server into an array.
+   * Parse the attributes list from the EU Login Server into an array.
    *
    * @param \DOMElement $node
    *   An XML element containing attributes.

--- a/src/OeAuthenticationServiceProvider.php
+++ b/src/OeAuthenticationServiceProvider.php
@@ -17,7 +17,7 @@ class OeAuthenticationServiceProvider extends ServiceProviderBase {
    * {@inheritdoc}
    */
   public function alter(ContainerBuilder $container) {
-    // We provide a custom EuLogin validator.
+    // We provide a custom EU Login validator.
     // @todo remove this when OPENEUROPA-1206 gets in (patch gets created).
     $definition = $container->getDefinition('cas.validator');
     $definition->setClass('Drupal\oe_authentication\Service\EuLoginValidator');

--- a/src/Service/EuLoginValidator.php
+++ b/src/Service/EuLoginValidator.php
@@ -20,7 +20,7 @@ use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 class EuLoginValidator extends CasValidator {
 
   /**
-   * Stores EuLogin settings object.
+   * Stores EU Login settings object.
    *
    * @var \Drupal\Core\Config\Config
    */
@@ -65,7 +65,7 @@ class EuLoginValidator extends CasValidator {
             $path = 'proxyValidate';
           }
           else {
-            // Custom EuLogin validation path.
+            // Custom EU Login validation path.
             $path = 'serviceValidate';
           }
           break;
@@ -85,7 +85,7 @@ class EuLoginValidator extends CasValidator {
     $params = [];
     $params['service'] = $this->urlGenerator->generate('cas.service', $service_params, UrlGeneratorInterface::ABSOLUTE_URL);
     $params['ticket'] = $ticket;
-    // We add the necessary EuLogin parameters.
+    // We add the necessary EU Login parameters.
     $params['assuranceLevel'] = $this->euLoginSettings->get('assurance_level');
     $params['ticketTypes'] = $this->euLoginSettings->get('ticket_types');
     if ($this->settings->get('proxy.initialize')) {


### PR DESCRIPTION
## OPENEUROPA-1209

### Description

Change settings for CAS and module to have production values by default.
Set development values in task-runner file.

### Change log

- Changed: settings for CAS and module
- Added: Task and config values processing
