### PR TITLE
OPENEUROPA-1227: EULogin validation service path is wrong

### DIFF
--- a/config/install/oe_authentication.settings.yml
+++ b/config/install/oe_authentication.settings.yml
@@ -1,4 +1,4 @@
 register_path: 'eim/external/register.cgi'
-validation_path: 'ticketValidation'
+validation_path: 'TicketValidationService'
 assurance_level: TOP
 ticket_types: SERVICE,PROXY


### PR DESCRIPTION
## OPENEUROPA-[Insert ticket number here]

### Description

Fixed.

### Change log

- Added:
- Changed:
- Deprecated:
- Removed:
- Fixed:
- Security:

### Commands

```sh
[Insert commands here]

```

