### PR TITLE
OPENEUROPA-1260: Fix authentication logout redirect for the demo server.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,8 @@
         "openeuropa/drupal-core-require-dev": "^8.6",
         "openeuropa/task-runner": "~1.0",
         "phpunit/phpunit": "~6.0",
-        "symfony/browser-kit": "~3.0||~4.0"
+        "symfony/browser-kit": "~3.0||~4.0",
+        "consolidation/robo": "^1.3"
     },
     "scripts": {
         "drupal-scaffold": "DrupalComposer\\DrupalScaffold\\Plugin::scaffold",

--- a/oe_authentication.install
+++ b/oe_authentication.install
@@ -18,6 +18,7 @@ function oe_authentication_install() {
   \Drupal::configFactory()->getEditable('cas.settings')
     ->set('server.hostname', 'ecas.ec.europa.eu')
     ->set('server.path', '/cas')
+    ->set('server.version', '3')
     ->set('forced_login.enabled', TRUE)
     ->set('forced_login.paths.pages', '/user/login')
     ->set('logout.cas_logout', TRUE)

--- a/oe_authentication.install
+++ b/oe_authentication.install
@@ -18,7 +18,7 @@ function oe_authentication_install() {
   \Drupal::configFactory()->getEditable('cas.settings')
     ->set('server.hostname', 'ecas.ec.europa.eu')
     ->set('server.path', '/cas')
-    ->set('server.version', '3')
+    ->set('server.version', '3.0')
     ->set('forced_login.enabled', TRUE)
     ->set('forced_login.paths.pages', '/user/login')
     ->set('logout.cas_logout', TRUE)

--- a/runner.yml.dist
+++ b/runner.yml.dist
@@ -35,7 +35,7 @@ commands:
         $config['cas.settings']['server']['hostname'] = 'authentication';
         $config['cas.settings']['server']['port'] = '8001';
         $config['cas.settings']['server']['path'] = '/';
-        $config['cas.settings']['server']['version'] = '3';
+        $config['cas.settings']['server']['version'] = '3.0';
         $config['oe_authentication.settings']['register_path'] = 'register';
         $config['oe_authentication.settings']['validation_path'] = 'serviceValidate';
 

--- a/runner.yml.dist
+++ b/runner.yml.dist
@@ -35,6 +35,7 @@ commands:
         $config['cas.settings']['server']['hostname'] = 'authentication';
         $config['cas.settings']['server']['port'] = '8001';
         $config['cas.settings']['server']['path'] = '/';
+        $config['cas.settings']['server']['version'] = '3';
         $config['oe_authentication.settings']['register_path'] = 'register';
         $config['oe_authentication.settings']['validation_path'] = 'serviceValidate';
 

--- a/tests/features/login.feature
+++ b/tests/features/login.feature
@@ -3,6 +3,7 @@ Feature: Login through OE Authentication
   In order to be able to access the CMS backend
   As user of the system
   I need to login through OE Authentication
+  I need to be redirect back to the site
 
   Scenario: Login
     Given I am on the homepage
@@ -15,9 +16,4 @@ Feature: Login through OE Authentication
     # Redirected back to Drupal.
     Then I click "My account"
     And I should see text matching "Dr. Lektroluv"
-
-    Then I click "Log out"
-    When I am on the homepage
-    Then I should not see the link "My account"
-    And I should see the link "Log in"
 

--- a/tests/features/logout.feature
+++ b/tests/features/logout.feature
@@ -1,0 +1,22 @@
+@api
+Feature: Logout through OE Authentication
+  In order to be able to logout
+  As user of the system
+  I need to logout through OE Authentication
+  I must be redirect back to the site
+
+  Scenario: Logout
+    Given I am on the homepage
+    Then I click "Log in"
+
+    # We are redirected to the mock OE Authentication server at this point.
+    Then I fill in "User" with "Kevin"
+    Then I fill in "Nickname" with "Kevin"
+    Then I fill in "Password" with "Kevin"
+    And I press the "Submit" button
+
+    Then I click "Log out"
+    When I am on the homepage
+    Then I should not see the link "My account"
+    And I should see the link "Log in"
+


### PR DESCRIPTION
## OPENEUROPA-1260

### Description

Currently, if logged in with the Pcas Demo server using the oe_authentication component, the logout action fails as no redirect URL can be built to redirect back to (see attachment)

Fix this so that login in with the demo server works. If needed, PR should be opened also on pcas demo.
