### PR TITLE
OPENEUROPA-1485: Add drupal patch to prevent blocked users from loggi…

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -53,6 +53,11 @@
             "build/profiles/contrib/{$name}": ["type:drupal-profile"],
             "build/modules/contrib/{$name}": ["type:drupal-module"],
             "build/themes/contrib/{$name}": ["type:drupal-theme"]
+        },
+        "patches": {
+            "drupal/cas": {
+                "https://www.drupal.org/project/cas/issues/3020014": "https://www.drupal.org/files/issues/2018-12-12/3020014-2.patch"
+            }
         }
     },
     "config": {


### PR DESCRIPTION
…ng in.

## OPENEUROPA-1485

### Description

Users loging in with ecas get a success message even when they don't log in. A patch was proposed to fix this.

### Change log

- Added: Drupal 3020014 patch added