### PR TITLE
OPENEUROPA-1486: Remove access to user delete.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,6 +18,7 @@
         "drupal/devel": "~1.2",
         "drupal/drupal-extension": "~4.0",
         "drush/drush": "~9.0@stable",
+        "egulias/email-validator": "^1.2.1",
         "nikic/php-parser": "~3.0",
         "openeuropa/behat-transformation-context" : "~0.1",
         "openeuropa/code-review": "~1.0.0-alpha4",

--- a/oe_authentication.module
+++ b/oe_authentication.module
@@ -7,14 +7,12 @@
 
 declare(strict_types = 1);
 
-use Drupal\Core\Form\FormStateInterface;
-
 /**
- * Implements hook_form__FORM_ID_alter().
+ * Implements hook_user_cancel_methods_alter().
  *
  * Remove the option to delete users while keeping the option to block them.
  */
-function oe_authentication_form_user_cancel_form_alter(&$form, FormStateInterface $form_state) {
+function oe_authentication_user_cancel_methods_alter(&$methods) {
   $user = \Drupal::currentUser();
   if (!$user->hasPermission('delete user')) {
     $restricted_options = [
@@ -22,7 +20,7 @@ function oe_authentication_form_user_cancel_form_alter(&$form, FormStateInterfac
       'user_cancel_delete',
     ];
     foreach ($restricted_options as $restricted_option) {
-      unset($form['user_cancel_method']['#options'][$restricted_option]);
+      unset($methods[$restricted_option]);
     }
   }
 }

--- a/oe_authentication.module
+++ b/oe_authentication.module
@@ -7,17 +7,19 @@
 
 declare(strict_types = 1);
 
-use Drupal\Core\Access\AccessResult;
-use Drupal\Core\Session\AccountInterface;
-use Drupal\user\UserInterface;
+use Drupal\Core\Form\FormStateInterface;
 
 /**
- * Implements hook_ENTITY_TYPE_access() for entity type "user".
+ * Implements hook_form__FORM_ID_alter().
  *
- * Prevent users from being deleted.
+ * Remove the option to delete users while keeping the option to block them.
  */
-function oe_authentication_user_access(UserInterface $entity, $op, AccountInterface $account) {
-  if ($op == 'delete') {
-    return AccessResult::forbidden();
+function oe_authentication_form_user_cancel_form_alter(&$form, FormStateInterface $form_state) {
+  $restricted_options = [
+    'user_cancel_reassign',
+    'user_cancel_delete',
+  ];
+  foreach ($restricted_options as $restricted_option) {
+    unset($form['user_cancel_method']['#options'][$restricted_option]);
   }
 }

--- a/oe_authentication.module
+++ b/oe_authentication.module
@@ -13,14 +13,11 @@ declare(strict_types = 1);
  * Remove the option to delete users while keeping the option to block them.
  */
 function oe_authentication_user_cancel_methods_alter(&$methods) {
-  $user = \Drupal::currentUser();
-  if (!$user->hasPermission('delete user')) {
-    $restricted_options = [
-      'user_cancel_reassign',
-      'user_cancel_delete',
-    ];
-    foreach ($restricted_options as $restricted_option) {
-      unset($methods[$restricted_option]);
-    }
+  $restricted_options = [
+    'user_cancel_reassign',
+    'user_cancel_delete',
+  ];
+  foreach ($restricted_options as $restricted_option) {
+    unset($methods[$restricted_option]);
   }
 }

--- a/oe_authentication.module
+++ b/oe_authentication.module
@@ -15,11 +15,14 @@ use Drupal\Core\Form\FormStateInterface;
  * Remove the option to delete users while keeping the option to block them.
  */
 function oe_authentication_form_user_cancel_form_alter(&$form, FormStateInterface $form_state) {
-  $restricted_options = [
-    'user_cancel_reassign',
-    'user_cancel_delete',
-  ];
-  foreach ($restricted_options as $restricted_option) {
-    unset($form['user_cancel_method']['#options'][$restricted_option]);
+  $user = \Drupal::currentUser();
+  if (!$user->hasPermission('delete user')) {
+    $restricted_options = [
+      'user_cancel_reassign',
+      'user_cancel_delete',
+    ];
+    foreach ($restricted_options as $restricted_option) {
+      unset($form['user_cancel_method']['#options'][$restricted_option]);
+    }
   }
 }

--- a/oe_authentication.module
+++ b/oe_authentication.module
@@ -6,3 +6,18 @@
  */
 
 declare(strict_types = 1);
+
+use Drupal\Core\Access\AccessResult;
+use Drupal\Core\Session\AccountInterface;
+use Drupal\user\UserInterface;
+
+/**
+ * Implements hook_ENTITY_TYPE_access() for entity type "user".
+ *
+ * Prevent users from being deleted.
+ */
+function oe_authentication_user_access(UserInterface $entity, $op, AccountInterface $account) {
+  if ($op == 'delete') {
+    return AccessResult::forbidden();
+  }
+}

--- a/oe_authentication.permissions.yml
+++ b/oe_authentication.permissions.yml
@@ -1,3 +1,7 @@
 administer authentication configuration:
   title: 'Administer Authentication configuration'
   restrict access: false
+
+delete user:
+  title: 'Delete users'
+  description: 'Delete users from the site.'

--- a/oe_authentication.permissions.yml
+++ b/oe_authentication.permissions.yml
@@ -1,7 +1,3 @@
 administer authentication configuration:
   title: 'Administer Authentication configuration'
   restrict access: false
-
-delete user:
-  title: 'Delete users'
-  description: 'Delete users from the site.'

--- a/src/Routing/RouteSubscriber.php
+++ b/src/Routing/RouteSubscriber.php
@@ -17,11 +17,9 @@ class RouteSubscriber extends RouteSubscriberBase {
    * {@inheritdoc}
    */
   protected function alterRoutes(RouteCollection $collection): void {
-    // Only the user 1 has access to user creation and deletion on Drupal.
+    // Only the user 1 has access to user creation.
     $admin_routes = [
       'user.admin_create',
-      'user.multiple_cancel_confirm',
-      'user.cancel_confirm',
     ];
     foreach ($admin_routes as $admin_route) {
       if (($route = $collection->get($admin_route)) === NULL) {

--- a/tests/Behat/AuthenticationContext.php
+++ b/tests/Behat/AuthenticationContext.php
@@ -4,6 +4,8 @@ declare(strict_types = 1);
 
 namespace Drupal\Tests\oe_authentication\Behat;
 
+use Drupal\DrupalExtension\Context\ConfigContext;
+use Drupal\user\Entity\User;
 use Behat\Behat\Hook\Scope\BeforeScenarioScope;
 use Drupal\DrupalExtension\Context\RawDrupalContext;
 
@@ -101,6 +103,20 @@ class AuthenticationContext extends RawDrupalContext {
     foreach ($configs as $key => $value) {
       $this->configContext->setConfig($name, $key, $value);
     }
+  }
+
+  /**
+   * Navigates to the current user's page.
+   *
+   * @Given I visit my user page
+   */
+  public function visitOwnUserPage(): void {
+    $current_user = $this->getUserManager()->getCurrentUser();
+    /** @var \Drupal\user\Entity\User $user */
+    $user = User::load($current_user->uid);
+    /** @var \Drupal\Core\Url $url */
+    $url = $user->toUrl();
+    $this->visitPath($url->getInternalPath());
   }
 
 }

--- a/tests/features/user-management.feature
+++ b/tests/features/user-management.feature
@@ -1,4 +1,4 @@
-@api @javascript
+@api
 Feature: Manage users
   In order to manage the users of the site
   As an administrator with the appropriate rights

--- a/tests/features/user-management.feature
+++ b/tests/features/user-management.feature
@@ -1,0 +1,21 @@
+@api @javascript
+Feature: Manage users
+  In order to manage the users of the site
+  As an administrator with the appropriate rights
+  I need to be able to edit and delete users
+
+  Scenario: A user with the appropriate rights can delete users.
+    Given the site is configured to use Drupal login
+    And I am logged in as a user with the "administer users, delete user" permissions
+    When I visit my user page
+    And I click "Edit"
+    And I press "Cancel account"
+    Then I should see "Delete the account and its content."
+
+  Scenario: A user without the appropriate rights can't delete users.
+    Given the site is configured to use Drupal login
+    And I am logged in as a user with the "administer users" permissions
+    When I visit my user page
+    And I click "Edit"
+    And I press "Cancel account"
+    Then I should not see "Delete the account and its content."

--- a/tests/features/user-management.feature
+++ b/tests/features/user-management.feature
@@ -1,21 +1,14 @@
 @api
 Feature: Manage users
-  In order to manage the users of the site
-  As an administrator with the appropriate rights
-  I need to be able to edit and delete users
+  Because users are managed externally
+  I should not be able to delete users on the site
 
-  Scenario: A user with the appropriate rights can delete users.
-    Given the site is configured to use Drupal login
-    And I am logged in as a user with the "administer users, delete user" permissions
-    When I visit my user page
-    And I click "Edit"
-    And I press "Cancel account"
-    Then I should see "Delete the account and its content."
-
-  Scenario: A user without the appropriate rights can't delete users.
+  Scenario: Users should not be able to delete other users
     Given the site is configured to use Drupal login
     And I am logged in as a user with the "administer users" permissions
     When I visit my user page
     And I click "Edit"
     And I press "Cancel account"
+    Then I should see "Disable the account and keep its content."
     Then I should not see "Delete the account and its content."
+    


### PR DESCRIPTION
## OPENEUROPA-1486
### Description

A user that is deleted on the site will be recreated as soon as he logs in again using EU Login. The scope of this issue is to disable the ability to delete a user, even for user 1.

### Change log

- Removed: Access to user delete
