### PR TITLE
OPENEUROPA-1522: Make sure we don't use Drupal paths in Behat scenarios.

### DIFF
--- a/behat.yml.dist
+++ b/behat.yml.dist
@@ -12,7 +12,7 @@ default:
         - OpenEuropa\Behat\TransformationContext:
             pages:
               Authentication configuration: 'admin/config/system/oe_authentication'
-              Register: '/user/register'
+              user registration: '/user/register'
   extensions:
     Behat\MinkExtension:
       goutte: ~

--- a/behat.yml.dist
+++ b/behat.yml.dist
@@ -12,6 +12,7 @@ default:
         - OpenEuropa\Behat\TransformationContext:
             pages:
               Authentication configuration: 'admin/config/system/oe_authentication'
+              Register: '/user/register'
   extensions:
     Behat\MinkExtension:
       goutte: ~

--- a/tests/features/ecas-register.feature
+++ b/tests/features/ecas-register.feature
@@ -6,7 +6,7 @@ Feature: Register through OE Authentication
 
   Scenario: Register
     Given I am an anonymous user
-    And I visit "the Register page"
+    And I visit "the user registration page"
 
     # Redirected to the Ecas mockup server.
     Then I should see "Create an account"

--- a/tests/features/ecas-register.feature
+++ b/tests/features/ecas-register.feature
@@ -6,7 +6,7 @@ Feature: Register through OE Authentication
 
   Scenario: Register
     Given I am an anonymous user
-    And I visit "/user/register"
+    And I visit "the Register page"
 
     # Redirected to the Ecas mockup server.
     Then I should see "Create an account"


### PR DESCRIPTION
## OPENEUROPA-1522

### Description

In our Behat scenarios we often have:
```
   Scenario: Create Webtools Analytics settings
    Given I am logged in as a user with the "administer webtools analytics" permission
    And I am on "admin/config/system/oe_webtools_analytics"
```

The step "And I am on "admin/config/system/oe_webtools_analytics"" is clearly not something that business can understand.

We have created a [transformation context|https://github.com/openeuropa/behat-transformation-context] to tackle these kind of situations.

The scope of this issue is to review Behat tests on all our components and turn steps like the one above into business-friendly ones by using the transformation context.
