### PR TITLE
OPENEUROPA-1520: Use drupal core.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
     "prefer-stable": true,
     "require": {
         "drupal/cas": "dev-1.x",
-        "openeuropa/drupal-core-require": "^8.6",
+        "drupal/core": "^8.6",
         "php": "^7.1"
     },
     "require-dev": {


### PR DESCRIPTION
## OPENEUROPA-1520

### Description

Remove drupal-core-require and use drupal/core
### Change log

- Added:
- Changed: Remove drupal-core-require and use drupal/core
- Deprecated:
- Removed:
- Fixed:
- Security:

### Commands

```sh
[Insert commands here]

```

