### PR TITLE
OPENEUROPA-1649: Add redirection on login error.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,8 @@
         "openeuropa/task-runner": "~1.0-beta4",
         "symfony/browser-kit": "~3.0||~4.0",
         "phpunit/phpunit": "~6.0",
-        "symfony/dom-crawler": "~3.4"
+        "symfony/dom-crawler": "~3.4",
+        "twig/twig": "1.37.1"
     },
     "scripts": {
         "post-install-cmd": "./vendor/bin/run drupal:site-setup",

--- a/oe_authentication.install
+++ b/oe_authentication.install
@@ -35,6 +35,7 @@ function oe_authentication_install(): void {
       ->set('user_accounts.email_hostname', 'localhost')
       ->set('login_link_enabled', TRUE)
       ->set('login_link_label', 'EU Login')
+      ->set('error_handling.login_failure_page', '/')
       ->save();
 
     \Drupal::messenger()->addMessage('Please be aware that oe_authentication makes changes to the following configuration: CAS settings.');

--- a/tests/features/ecas-login.feature
+++ b/tests/features/ecas-login.feature
@@ -91,4 +91,5 @@ Feature: Login through OE Authentication
     And I press the "Login!" button
     Then I should see "There was a problem logging in, please contact a site administrator."
     And I should see "Thank you for applying for an account. Your account is currently pending approval by the site administrator."
+    And I should be on the homepage
     And I should see the link "Log in"


### PR DESCRIPTION
## OPENEUROPA-1649

### Description

Add redirection to home page if login fails.

### Change log

- Added: Add redirection to home page if login fails.
- Changed:
- Deprecated:
- Removed:
- Fixed:
- Security:

### Commands

```sh
[Insert commands here]

```

