### PR TITLE
Issue 60: Prevent the usage of http-foundation latest version.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,6 +29,9 @@
         "symfony/dom-crawler": "~3.4",
         "twig/twig": "1.37.1"
     },
+    "conflict": {
+        "symfony/http-foundation": "3.4.24"
+    },
     "scripts": {
         "post-install-cmd": "./vendor/bin/run drupal:site-setup",
         "post-update-cmd": "./vendor/bin/run drupal:site-setup"


### PR DESCRIPTION
## Issue 60

### Description

After the latest symfony/http-foundation 3.4.24 update Drupal core has reported an issue with its lazy sessions: https://www.drupal.org/project/drupal/issues/3045349

The current solution is to fix the http-foundation version in te composer.json file:

"conflict": { "symfony/http-foundation": "3.4.24" },

