### PR TITLE
OPENEUROPA-1713: Adjust/correct behat tests of component.

### DIFF
--- a/behat.yml.dist
+++ b/behat.yml.dist
@@ -9,6 +9,7 @@ default:
         - Drupal\DrupalExtension\Context\MessageContext
         - Drupal\DrupalExtension\Context\MinkContext
         - Drupal\Tests\oe_authentication\Behat\AuthenticationContext
+        - Drupal\Tests\oe_authentication\Behat\CleanupContext
         - OpenEuropa\Behat\TransformationContext:
             pages:
               Authentication configuration: 'admin/config/system/oe_authentication'

--- a/tests/Behat/AuthenticationContext.php
+++ b/tests/Behat/AuthenticationContext.php
@@ -138,7 +138,7 @@ class AuthenticationContext extends RawDrupalContext {
   }
 
   /**
-   * We reset the authentication mock to the state it was when we found it.
+   * We reset the authentication mock to the state as it was.
    *
    * @AfterScenario @ecas-login
    */
@@ -155,23 +155,8 @@ class AuthenticationContext extends RawDrupalContext {
    * @BeforeScenario @AllowExternalLogin
    */
   public function allowExternalUsers(): void {
-    // Set the assurance level to allow also external users to login. Security
-    // implications are mitigated by the fact that users are by default blocked
-    // when they login for the first time if they don't yet exist.
-    $config = \Drupal::configFactory()->getEditable('oe_authentication.settings');
-    $config->set('assurance_level', 'LOW');
-    $config->save();
-  }
-
-  /**
-   * Disallow external users to login.
-   *
-   * @AfterScenario @AllowExternalLogin
-   */
-  public function disallowExternalUsers(): void {
-    $config = \Drupal::configFactory()->getEditable('oe_authentication.settings');
-    $config->set('assurance_level', 'TOP');
-    $config->save();
+    // Set the assurance level to allow also external users to login.
+    $this->configContext->setConfig('oe_authentication.settings', 'assurance_level', 'LOW');
   }
 
 }

--- a/tests/Behat/AuthenticationContext.php
+++ b/tests/Behat/AuthenticationContext.php
@@ -137,4 +137,41 @@ class AuthenticationContext extends RawDrupalContext {
     $this->configContext->setConfig('user.settings', 'register', USER_REGISTER_VISITORS_ADMINISTRATIVE_APPROVAL);
   }
 
+  /**
+   * We reset the authentication mock to the state it was when we found it.
+   *
+   * @AfterScenario @ecas-login
+   */
+  public function resetAuthenticationMock(): void {
+    $this->visitPath('user/login');
+    if ($this->getSession()->getPage()->hasLink('Change it')) {
+      $this->getSession()->getPage()->clickLink('Change it');
+    }
+  }
+
+  /**
+   * Allow external users to login.
+   *
+   * @BeforeScenario @AllowExternalLogin
+   */
+  public function allowExternalUsers(): void {
+    // Set the assurance level to allow also external users to login. Security
+    // implications are mitigated by the fact that users are by default blocked
+    // when they login for the first time if they don't yet exist.
+    $config = \Drupal::configFactory()->getEditable('oe_authentication.settings');
+    $config->set('assurance_level', 'LOW');
+    $config->save();
+  }
+
+  /**
+   * Disallow external users to login.
+   *
+   * @AfterScenario @AllowExternalLogin
+   */
+  public function disallowExternalUsers(): void {
+    $config = \Drupal::configFactory()->getEditable('oe_authentication.settings');
+    $config->set('assurance_level', 'TOP');
+    $config->save();
+  }
+
 }

--- a/tests/Behat/CleanupContext.php
+++ b/tests/Behat/CleanupContext.php
@@ -1,0 +1,106 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Drupal\Tests\oe_authentication\Behat;
+
+use Behat\Behat\Hook\Scope\AfterScenarioScope;
+use Behat\Behat\Hook\Scope\BeforeScenarioScope;
+use Behat\Gherkin\Node\ScenarioInterface;
+use Drupal\DrupalExtension\Context\RawDrupalContext;
+
+/**
+ * Context to clean up entities created through the UI during scenarios.
+ */
+class CleanupContext extends RawDrupalContext {
+
+  /**
+   * The IDs of the existing entities in the system, keyed by entity type.
+   *
+   * @var array
+   */
+  protected $existing = [];
+
+  /**
+   * The PIDs of the existing url aliases.
+   *
+   * @var array
+   */
+  protected $existingAliases = [];
+
+  /**
+   * Collect the IDs of entities existing before the execution of the scenario.
+   *
+   * Entity types can be marked for cleanup by adding a tag that starts with
+   * "cleanup:" followed by the entity type machine name.
+   *
+   * @param \Behat\Behat\Hook\Scope\BeforeScenarioScope $scope
+   *   The scenario scope.
+   *
+   * @beforeScenario
+   */
+  public function collectExistingEntities(BeforeScenarioScope $scope): void {
+    // Reset the entity list at the beginning of each scenario.
+    $this->existing = [];
+
+    $entity_types = $this->getEntityTypesToCleanup($scope->getScenario());
+    foreach ($entity_types as $entity_type) {
+      $this->existing[$entity_type] = $this->getAllEntityIdsOfType($entity_type);
+    }
+  }
+
+  /**
+   * Deletes entities of specified type created though the scenario.
+   *
+   * @param \Behat\Behat\Hook\Scope\AfterScenarioScope $scope
+   *   The scenario scope.
+   *
+   * @afterScenario
+   */
+  public function cleanupCreatedEntities(AfterScenarioScope $scope): void {
+    foreach ($this->existing as $entity_type => $ids) {
+      $current_ids = $this->getAllEntityIdsOfType($entity_type);
+      $test_entity_ids = array_diff($current_ids, $ids);
+
+      if ($test_entity_ids) {
+        $storage = \Drupal::entityTypeManager()->getStorage($entity_type);
+        $storage->delete($storage->loadMultiple($test_entity_ids));
+      }
+    }
+  }
+
+  /**
+   * Returns the entity types marked for cleanup in a scenario.
+   *
+   * @param \Behat\Gherkin\Node\ScenarioInterface $scenario
+   *   The test scenario.
+   *
+   * @return string[]
+   *   A list of entity types marked for cleanup.
+   */
+  protected function getEntityTypesToCleanup(ScenarioInterface $scenario): array {
+    $entity_types = [];
+
+    foreach ($scenario->getTags() as $tag) {
+      if (strpos($tag, 'cleanup:') === 0) {
+        $entity_types[] = substr($tag, 8);
+      }
+    }
+
+    return $entity_types;
+  }
+
+  /**
+   * Returns the IDs of all the entities of a certain type.
+   *
+   * @param string $entity_type
+   *   The entity type.
+   *
+   * @return int[]
+   *   An array of entity IDs.
+   */
+  protected function getAllEntityIdsOfType(string $entity_type): array {
+    return \Drupal::entityTypeManager()->getStorage($entity_type)->getQuery()->execute();
+  }
+
+}

--- a/tests/features/ecas-login.feature
+++ b/tests/features/ecas-login.feature
@@ -1,11 +1,12 @@
-@api @javascript
+@api @javascript @ecas-login
 Feature: Login through OE Authentication
   In order to be able to access the CMS backend
   As user of the system
   I need to login through OE Authentication
   I need to be redirect back to the site
 
-  Scenario: Login/Logout with eCAS mockup server
+  @cleanup:user
+  Scenario: Login/Logout with eCAS mockup server of internal users
     Given the site is configured to make users active on creation
     When I am on the homepage
     And I click "Log in"
@@ -40,11 +41,49 @@ Feature: Login through OE Authentication
     And I should not see the link "Log out"
     And I should see the link "Log in"
 
+  @cleanup:user @BackupAuthConfigs @AllowExternalLogin
+  Scenario: Login/Logout with eCAS mockup server of external users
+    Given the site is configured to make users active on creation
+    When I am on the homepage
+    And I click "Log in"
+    And I click "External"
+    # Redirected to the mock server.
+    And I fill in "Username or e-mail address" with "007@mi6.eu"
+    And I fill in "Password" with "shaken_not_stirred"
+    And I press the "Login!" button
+    # Redirected back to Drupal.
+    Then I should see "You have been logged in."
+    And I should see the link "My account"
+    And I should see the link "Log out"
+    And I should not see the link "Log in"
+    # Redirected back to Drupal.
+
+    When I click "My account"
+    Then I should see the heading "jb007"
+
+    # Profile contains extra fields.
+    When I click "Edit"
+    Then the "First Name" field should contain "James"
+    And the "Last Name" field should contain "BOND"
+    And the "Department" field should contain "DIGIT.A.3.001"
+    And the "Organisation" field should contain "external"
+
+    When I click "Log out"
+    # Redirected to the Ecas mockup server.
+    And I press the "Log me out" button
+    # Redirected back to Drupal.
+    Then I should be on the homepage
+    And I should not see the link "My account"
+    And I should not see the link "Log out"
+    And I should see the link "Log in"
+
+  @cleanup:user
   Scenario: A user's information should update every login
     # Login with an EULogin user.
     Given the site is configured to make users active on creation
     When I am on the homepage
     And I click "Log in"
+    And I click "European Commission"
     And I fill in "Username or e-mail address" with "texasranger@chucknorris.com.eu"
     And I fill in "Password" with "Qwerty098"
     And I press the "Login!" button
@@ -77,11 +116,13 @@ Feature: Login through OE Authentication
     And I press the "Log me out" button
     Then I should be on the homepage
 
+  @cleanup:user
   Scenario: A site that requires administration validation on users should block them by default
     # When I try to log in again I will be denied access.
     Given the site is configured to make users blocked on creation
     When I am on the homepage
     And I click "Log in"
+    And I click "European Commission"
     And I fill in "Username or e-mail address" with "Lisbeth.SALANDER@ext.ec.europa.eu"
     And I fill in "Password" with "dragon_tattoo"
     And I press the "Login!" button

--- a/tests/features/ecas-login.feature
+++ b/tests/features/ecas-login.feature
@@ -20,8 +20,8 @@ Feature: Login through OE Authentication
     And I should see the link "My account"
     And I should see the link "Log out"
     And I should not see the link "Log in"
-    # Redirected back to Drupal.
 
+    # Redirected back to Drupal.
     When I click "My account"
     Then I should see the heading "chucknorris"
 
@@ -56,8 +56,8 @@ Feature: Login through OE Authentication
     And I should see the link "My account"
     And I should see the link "Log out"
     And I should not see the link "Log in"
-    # Redirected back to Drupal.
 
+    # Redirected back to Drupal.
     When I click "My account"
     Then I should see the heading "jb007"
 

--- a/tests/features/ecas-register.feature
+++ b/tests/features/ecas-register.feature
@@ -1,4 +1,4 @@
-@javascript
+@javascript @ecas-login
 Feature: Register through OE Authentication
   In order to be able to have new users
   As an anonymous user of the system
@@ -8,4 +8,5 @@ Feature: Register through OE Authentication
     Given I am an anonymous user
     When I visit "the user registration page"
     # Redirected to the Ecas mockup server.
+    And I click "External"
     Then I should see "Create an account"


### PR DESCRIPTION
## OPENEUROPA-1713

### Description

Currently we are able to have green behat tests only at first time. On other we are getting failed scenarios. It is related to fact that we are creating/blocking users and didn't remove/unblock after scenario.
+ Aligning with ticket OPENEUROPA-1840

### Change log

- Added:
- Changed:
- Deprecated:
- Removed:
- Fixed:
- Security:

### Commands

```sh
[Insert commands here]

```

