### PR TITLE
OPENEUROPA-1750: Allow user 1 to delete users.

### DIFF
--- a/oe_authentication.module
+++ b/oe_authentication.module
@@ -16,6 +16,9 @@ use Drupal\Core\Field\BaseFieldDefinition;
  * Remove the option to delete users while keeping the option to block them.
  */
 function oe_authentication_user_cancel_methods_alter(&$methods) {
+  if (\Drupal::currentUser()->id() == 1) {
+    return;
+  }
   $restricted_options = [
     'user_cancel_reassign',
     'user_cancel_delete',


### PR DESCRIPTION
## OPENEUROPA-1750

### Description

Allow User 1 to delete user accounts in Drupal

### Change log

- Added:
- Changed: Allow User 1 to delete user accounts in Drupal
- Deprecated:
- Removed:
- Fixed:
- Security:

### Commands

```sh
[Insert commands here]

```

