### PR TITLE
OPENEUROPA-1836: Restrict drupal user creation to user 1.

### DIFF
--- a/oe_authentication.services.yml
+++ b/oe_authentication.services.yml
@@ -1,9 +1,13 @@
 services:
   oe_authentication.external_user_access_checker:
-      class: Drupal\oe_authentication\Access\ExternalUserAccessCheck
-      arguments: ['@externalauth.authmap']
-      tags:
-        - { name: access_check, applies_to: _external_user_access_check }
+    class: Drupal\oe_authentication\Access\ExternalUserAccessCheck
+    arguments: ['@externalauth.authmap']
+    tags:
+      - { name: access_check, applies_to: _external_user_access_check }
+  oe_authentication.superuser_access_checker:
+    class: Drupal\oe_authentication\Access\SuperUserAccessCheck
+    tags:
+      - { name: access_check, applies_to: _superuser_access_check }
   oe_authentication.route_subscriber:
     class: \Drupal\oe_authentication\Routing\RouteSubscriber
     tags:

--- a/src/Access/SuperUserAccessCheck.php
+++ b/src/Access/SuperUserAccessCheck.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Drupal\oe_authentication\Access;
+
+use Drupal\Core\Access\AccessResult;
+use Drupal\Core\Access\AccessResultInterface;
+use Drupal\Core\Routing\Access\AccessInterface;
+use Drupal\Core\Session\AccountInterface;
+
+/**
+ * Check whether a user has the uid 1.
+ */
+class SuperUserAccessCheck implements AccessInterface {
+
+  /**
+   * Checks access.
+   *
+   * @param \Drupal\Core\Session\AccountInterface $account
+   *   The logged in user key.
+   *
+   * @return \Drupal\Core\Access\AccessResultInterface
+   *   The access result.
+   */
+  public function access(AccountInterface $account): AccessResultInterface {
+    if ($account->id() == 1) {
+      return AccessResult::allowed();
+    }
+    return AccessResult::forbidden();
+  }
+
+}

--- a/src/Routing/RouteSubscriber.php
+++ b/src/Routing/RouteSubscriber.php
@@ -17,6 +17,17 @@ class RouteSubscriber extends RouteSubscriberBase {
    * {@inheritdoc}
    */
   protected function alterRoutes(RouteCollection $collection): void {
+    // Only the user 1 has access to user creation on Drupal.
+    $admin_routes = [
+      'user.admin_create',
+    ];
+    foreach ($admin_routes as $admin_route) {
+      if (($route = $collection->get($admin_route)) === NULL) {
+        continue;
+      }
+      $route->setRequirement('_superuser_access_check', 'TRUE');
+    }
+
     // Restrict Drupal login to Drupal only users.
     $internal_routes = [
       'user.pass',


### PR DESCRIPTION
## OPENEUROPA-1836

### Description

Restrict drupal user creation to user 1.

### Change log

- Added:
- Changed: Restrict drupal user creation to user 1.
- Deprecated:
- Removed:
- Fixed:
- Security:

### Commands

```sh
[Insert commands here]

```

