### PR TITLE
OPENEUROPA-1897: Removed drone permission fix.

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -50,13 +50,6 @@ pipeline:
     commands:
       - ./vendor/bin/run drupal:site-install
 
-  fix-permission:
-    image: fpfis/httpd-php-ci:7.1
-    commands:
-      # Workaround to fix the user permission issue. @todo Fix this on drone.
-      - ./vendor/bin/drush -y config-set system.performance css.preprocess 0
-      - ./vendor/bin/drush -y config-set system.performance js.preprocess 0
-
   test-grumphp:
     group: test
     image: fpfis/httpd-php-ci:7.1


### PR DESCRIPTION
## OPENEUROPA-1897

### Description

Removed drone permission fix

### Change log

- Added:
- Changed: Removed drone permission fix
- Deprecated:
- Removed:
- Fixed:
- Security:

### Commands

```sh
[Insert commands here]

```

