### PR TITLE
Move user fields into a sub-module

### DIFF
--- a/modules/oe_authentication_user_fields/oe_authentication_user_fields.info.yml
+++ b/modules/oe_authentication_user_fields/oe_authentication_user_fields.info.yml
@@ -1,0 +1,7 @@
+name: 'OE Authentication User Fields'
+description: 'Provides some user basic fields and map them with EU Login attributes.'
+package: OpenEuropa
+type: module
+core: 8.x
+dependencies:
+  - oe_authentication:oe_authentication

--- a/modules/oe_authentication_user_fields/oe_authentication_user_fields.module
+++ b/modules/oe_authentication_user_fields/oe_authentication_user_fields.module
@@ -13,10 +13,10 @@ use Drupal\Core\Field\BaseFieldDefinition;
 /**
  * Implements hook_entity_base_field_info().
  *
- * Add custom EU Login fields.
+ * Adds custom EU Login fields.
  */
 function oe_authentication_user_fields_entity_base_field_info(EntityTypeInterface $entity_type): array {
-  if ($entity_type->id() != 'user') {
+  if ($entity_type->id() !== 'user') {
     return [];
   }
   $custom_fields = [

--- a/modules/oe_authentication_user_fields/oe_authentication_user_fields.module
+++ b/modules/oe_authentication_user_fields/oe_authentication_user_fields.module
@@ -1,0 +1,60 @@
+<?php
+
+/**
+ * @file
+ * OpenEuropa Authentication User Fields module.
+ */
+
+declare(strict_types = 1);
+
+use Drupal\Core\Entity\EntityTypeInterface;
+use Drupal\Core\Field\BaseFieldDefinition;
+
+/**
+ * Implements hook_entity_base_field_info().
+ *
+ * Add custom EU Login fields.
+ */
+function oe_authentication_user_fields_entity_base_field_info(EntityTypeInterface $entity_type): array {
+  if ($entity_type->id() != 'user') {
+    return [];
+  }
+  $custom_fields = [
+    '7' => [
+      'machine_name' => 'field_oe_firstname',
+      'name' => t('First Name'),
+      'description' => t("User's first name."),
+    ],
+    '8' => [
+      'machine_name' => 'field_oe_lastname',
+      'name' => t('Last Name'),
+      'description' => t("User's last name."),
+    ],
+    '9' => [
+      'machine_name' => 'field_oe_department',
+      'name' => t('Department'),
+      'description' => t("User's department."),
+    ],
+    '10' => [
+      'machine_name' => 'field_oe_organisation',
+      'name' => t('Organisation'),
+      'description' => t("User's organisation."),
+    ],
+  ];
+
+  $fields = [];
+  foreach ($custom_fields as $weight => $field) {
+    $fields[$field['machine_name']] = BaseFieldDefinition::create('string')
+      ->setLabel($field['name'])
+      ->setDescription($field['description'])
+      ->setSettings([
+        'default_value' => '',
+        'max_length' => 255,
+      ])
+      ->setDisplayOptions('form', [
+        'weight' => $weight,
+        'region' => 'content',
+      ]);
+  }
+  return $fields;
+}

--- a/modules/oe_authentication_user_fields/oe_authentication_user_fields.services.yml
+++ b/modules/oe_authentication_user_fields/oe_authentication_user_fields.services.yml
@@ -1,0 +1,5 @@
+services:
+  oe_authentication_user_fields.event_subscriber:
+    class: Drupal\oe_authentication_user_fields\EventSubscriber\EuLoginAttributesToUserFieldsSubscriber
+    tags:
+      - { name: event_subscriber }

--- a/modules/oe_authentication_user_fields/src/EuLoginAttributesHelper.php
+++ b/modules/oe_authentication_user_fields/src/EuLoginAttributesHelper.php
@@ -10,7 +10,7 @@ namespace Drupal\oe_authentication_user_fields;
 class EuLoginAttributesHelper {
 
   /**
-   * Array mapping EU Login attributes with user account fields.
+   * Array mapping of EU Login attributes with user account fields.
    */
   const USER_EU_LOGIN_ATTRIBUTE_MAPPING = [
     'mail' => 'email',
@@ -21,13 +21,13 @@ class EuLoginAttributesHelper {
   ];
 
   /**
-   * Converts an array EU Login attributes into an array of Drupal field/values.
+   * Converts the EU Login attributes into a Drupal field/values array.
    *
    * @param array $attributes
    *   An array containing a series of EU Login attributes.
    *
    * @return array
-   *   An array containing a series of Drupal field names and values.
+   *   An associative array of field values indexed by the field name.
    */
   public static function convertEuLoginAttributesToFieldValues(array $attributes): array {
     $values = [];

--- a/modules/oe_authentication_user_fields/src/EuLoginAttributesHelper.php
+++ b/modules/oe_authentication_user_fields/src/EuLoginAttributesHelper.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Drupal\oe_authentication_user_fields;
+
+/**
+ * Helper functions to map EU Login attributes to user profile.
+ */
+class EuLoginAttributesHelper {
+
+  /**
+   * Array mapping EU Login attributes with user account fields.
+   */
+  const USER_EU_LOGIN_ATTRIBUTE_MAPPING = [
+    'mail' => 'email',
+    'field_oe_firstname' => 'firstName',
+    'field_oe_lastname' => 'lastName',
+    'field_oe_department' => 'departmentNumber',
+    'field_oe_organisation' => 'domain',
+  ];
+
+  /**
+   * Converts an array EU Login attributes into an array of Drupal field/values.
+   *
+   * @param array $attributes
+   *   An array containing a series of EU Login attributes.
+   *
+   * @return array
+   *   An array containing a series of Drupal field names and values.
+   */
+  public static function convertEuLoginAttributesToFieldValues(array $attributes): array {
+    $values = [];
+    foreach (static::USER_EU_LOGIN_ATTRIBUTE_MAPPING as $field_name => $property_name) {
+      if (!empty($attributes[$property_name])) {
+        $values[$field_name] = $attributes[$property_name];
+      }
+    }
+    return $values;
+  }
+
+}

--- a/modules/oe_authentication_user_fields/src/EventSubscriber/EuLoginAttributesToUserFieldsSubscriber.php
+++ b/modules/oe_authentication_user_fields/src/EventSubscriber/EuLoginAttributesToUserFieldsSubscriber.php
@@ -30,9 +30,6 @@ class EuLoginAttributesToUserFieldsSubscriber implements EventSubscriberInterfac
    *
    * @param \Drupal\cas\Event\CasPostLoginEvent $event
    *   The triggered event.
-   *
-   * @throws \Drupal\Core\Entity\EntityStorageException
-   *   In case of failures an exception is thrown.
    */
   public function updateUserData(CasPostLoginEvent $event): void {
     $properties = EuLoginAttributesHelper::convertEuLoginAttributesToFieldValues($event->getCasPropertyBag()->getAttributes());

--- a/modules/oe_authentication_user_fields/src/EventSubscriber/EuLoginAttributesToUserFieldsSubscriber.php
+++ b/modules/oe_authentication_user_fields/src/EventSubscriber/EuLoginAttributesToUserFieldsSubscriber.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Drupal\oe_authentication_user_fields\EventSubscriber;
+
+use Drupal\cas\Event\CasPostLoginEvent;
+use Drupal\cas\Event\CasPreRegisterEvent;
+use Drupal\cas\Service\CasHelper;
+use Drupal\oe_authentication_user_fields\EuLoginAttributesHelper;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+/**
+ * Copies the EU Login attributes to user fields.
+ */
+class EuLoginAttributesToUserFieldsSubscriber implements EventSubscriberInterface {
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function getSubscribedEvents() {
+    return [
+      CasHelper::EVENT_POST_LOGIN => 'updateUserData',
+      CasHelper::EVENT_PRE_REGISTER => 'processUserProperties',
+    ];
+  }
+
+  /**
+   * Updates the user data based on the information taken from EU Login.
+   *
+   * @param \Drupal\cas\Event\CasPostLoginEvent $event
+   *   The triggered event.
+   *
+   * @throws \Drupal\Core\Entity\EntityStorageException
+   *   In case of failures an exception is thrown.
+   */
+  public function updateUserData(CasPostLoginEvent $event): void {
+    $properties = EuLoginAttributesHelper::convertEuLoginAttributesToFieldValues($event->getCasPropertyBag()->getAttributes());
+    $account = $event->getAccount();
+    foreach ($properties as $name => $value) {
+      $account->set($name, $value);
+    }
+    $account->save();
+  }
+
+  /**
+   * Adds user properties based on the information taken from EU Login.
+   *
+   * @param \Drupal\cas\Event\CasPreRegisterEvent $event
+   *   The triggered event.
+   */
+  public function processUserProperties(CasPreRegisterEvent $event): void {
+    $attributes = $event->getCasPropertyBag()->getAttributes();
+    $event->setPropertyValues(EuLoginAttributesHelper::convertEuLoginAttributesToFieldValues($attributes));
+  }
+
+}

--- a/oe_authentication.install
+++ b/oe_authentication.install
@@ -91,7 +91,7 @@ function oe_authentication_update_8001(): void {
 }
 
 /**
- * Install oe_authentication_user_fields.module.
+ * Install oe_authentication_user_fields module.
  */
 function oe_authentication_update_8002(): void {
   $entity_definition_manager = \Drupal::entityDefinitionUpdateManager();

--- a/oe_authentication.install
+++ b/oe_authentication.install
@@ -89,3 +89,29 @@ function oe_authentication_update_8001(): void {
       ->installFieldStorageDefinition($field['name'], 'user', 'oe_authentication', $storage_definition);
   }
 }
+
+/**
+ * Install oe_authentication_user_fields.module.
+ */
+function oe_authentication_update_8002(): void {
+  $entity_definition_manager = \Drupal::entityDefinitionUpdateManager();
+
+  // Change the base fields provider.
+  $field_names = [
+    'field_oe_firstname',
+    'field_oe_lastname',
+    'field_oe_department',
+    'field_oe_organisation',
+  ];
+  foreach ($field_names as $field_name) {
+    $field_storage_definition = $entity_definition_manager->getFieldStorageDefinition($field_name, 'user');
+    $field_storage_definition->setProvider('oe_authentication_user_fields');
+    $entity_definition_manager->updateFieldStorageDefinition($field_storage_definition);
+  }
+
+  // Changing the base field provider requires container invalidation.
+  \Drupal::service('kernel')->invalidateContainer();
+
+  // Install the new sub-module.
+  \Drupal::service('module_installer')->install(['oe_authentication_user_fields']);
+}

--- a/oe_authentication.module
+++ b/oe_authentication.module
@@ -7,9 +7,6 @@
 
 declare(strict_types = 1);
 
-use Drupal\Core\Entity\EntityTypeInterface;
-use Drupal\Core\Field\BaseFieldDefinition;
-
 /**
  * Implements hook_user_cancel_methods_alter().
  *
@@ -26,55 +23,6 @@ function oe_authentication_user_cancel_methods_alter(&$methods) {
   foreach ($restricted_options as $restricted_option) {
     unset($methods[$restricted_option]);
   }
-}
-
-/**
- * Implements hook_entity_base_field_info().
- *
- * Add custom EULogin fields.
- */
-function oe_authentication_entity_base_field_info(EntityTypeInterface $entity_type) {
-  if ($entity_type->id() != 'user') {
-    return [];
-  }
-  $custom_fields = [
-    '7' => [
-      'machine_name' => 'field_oe_firstname',
-      'name' => t('First Name'),
-      'description' => t("User's first name."),
-    ],
-    '8' => [
-      'machine_name' => 'field_oe_lastname',
-      'name' => t('Last Name'),
-      'description' => t("User's last name."),
-    ],
-    '9' => [
-      'machine_name' => 'field_oe_department',
-      'name' => t('Department'),
-      'description' => t("User's department."),
-    ],
-    '10' => [
-      'machine_name' => 'field_oe_organisation',
-      'name' => t('Organisation'),
-      'description' => t("User's organisation."),
-    ],
-  ];
-
-  $fields = [];
-  foreach ($custom_fields as $weight => $field) {
-    $fields[$field['machine_name']] = BaseFieldDefinition::create('string')
-      ->setLabel($field['name'])
-      ->setDescription($field['description'])
-      ->setSettings([
-        'default_value' => '',
-        'max_length' => 255,
-      ])
-      ->setDisplayOptions('form', [
-        'weight' => $weight,
-        'region' => 'content',
-      ]);
-  }
-  return $fields;
 }
 
 /**

--- a/oe_authentication.post_update.php
+++ b/oe_authentication.post_update.php
@@ -2,7 +2,7 @@
 
 /**
  * @file
- * OpenEuropa Authentication post updates.
+ * Post update functions for OE Authentication module.
  */
 
 declare(strict_types = 1);

--- a/runner.yml.dist
+++ b/runner.yml.dist
@@ -15,7 +15,7 @@ drupal:
     - "./vendor/bin/drush en toolbar -y"
     - "./vendor/bin/drush en config_devel -y"
     # Enable the modules.
-    - "./vendor/bin/drush en oe_authentication -y"
+    - "./vendor/bin/drush en oe_authentication_user_fields -y"
     - "./vendor/bin/drush pmu big_pipe -y"
     - "./vendor/bin/drush cr"
   settings:

--- a/src/CasProcessor.php
+++ b/src/CasProcessor.php
@@ -10,36 +10,6 @@ namespace Drupal\oe_authentication;
 class CasProcessor {
 
   /**
-   * Array mapping CAS attributes with oe_authentication fields.
-   */
-  const USER_CAS_ATTRIBUTE_MAPPING = [
-    'mail' => 'email',
-    'field_oe_firstname' => 'firstName',
-    'field_oe_lastname' => 'lastName',
-    'field_oe_department' => 'departmentNumber',
-    'field_oe_organisation' => 'domain',
-  ];
-
-  /**
-   * Converts an array of cas attributes into an array of drupal field/values.
-   *
-   * @param array $attributes
-   *   An array containing a series of cas attributes.
-   *
-   * @return array
-   *   An array containing a series of Drupal field names and values.
-   */
-  public static function convertCasAttributesToFieldValues(array $attributes): array {
-    $values = [];
-    foreach (static::USER_CAS_ATTRIBUTE_MAPPING as $field_name => $property_name) {
-      if (!empty($attributes[$property_name])) {
-        $values[$field_name] = $attributes[$property_name];
-      }
-    }
-    return $values;
-  }
-
-  /**
    * Parses the EU Login attributes from the validation response.
    *
    * @param string $source

--- a/tests/features/ecas-login.feature
+++ b/tests/features/ecas-login.feature
@@ -89,6 +89,9 @@ Feature: Login through OE Authentication
     And I press the "Login!" button
     And I click "Edit"
     Then the "First Name" field should contain "Chuck"
+    And the "Last Name" field should contain "NORRIS"
+    And the "Department" field should contain "DIGIT.A.3.001"
+    And the "Organisation" field should contain "eu.europa.ec"
 
     # Edit the details.
     When I fill in "First Name" with "New name"
@@ -97,6 +100,9 @@ Feature: Login through OE Authentication
 
     When I click "Edit"
     Then the "First Name" field should contain "New name"
+    And the "Last Name" field should contain "NORRIS"
+    And the "Department" field should contain "DIGIT.A.3.001"
+    And the "Organisation" field should contain "eu.europa.ec"
 
     # Logout.
     When I click "Log out"
@@ -110,6 +116,9 @@ Feature: Login through OE Authentication
     And I press the "Login!" button
     And I click "Edit"
     Then the "First Name" field should contain "Chuck"
+    And the "Last Name" field should contain "NORRIS"
+    And the "Department" field should contain "DIGIT.A.3.001"
+    And the "Organisation" field should contain "eu.europa.ec"
 
     #Logout to continue scenarios.
     When I click "Log out"


### PR DESCRIPTION
Fixes #81

# QA notes

## Clean install

Is covered by the Behat tests.

## Testing the update path

Install de development environment according to the README.md.

```bash
git checkout master
./vendor/bin/run drupal:site-setup
./vendor/bin/run drupal:site-install
./vendor/bin/drush -l http://localhost/path/to/site/ uli
```

Go to `/admin/reports/status` and check that there are no Entity/Field Definitions mismatch errors.

Do a login for a test user (see the eCAS Mock Server users data) and, in the `users_field_data` table, check that the profile fields (`field_oe_*`) are correctly filled.

```bash
git checkout 81-user-fields
./vendor/bin/drush updb -y
```

Refresh `/admin/reports/status` and check that there are no Entity/Field Definitions mismatch errors.

Check the `users_field_data` table. The fields should be filled with the previous data.