### PR TITLE
OPENEUROPA-2259: Fix behat/mink-selenium2-driver missing branch by aliasing.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,11 +28,15 @@
         "openeuropa/task-runner": "~1.0-beta4",
         "symfony/browser-kit": "~3.0||~4.0",
         "phpunit/phpunit": "~6.0",
-        "symfony/dom-crawler": "~3.4"
+        "symfony/dom-crawler": "~3.4",
+        "behat/mink-selenium2-driver": "dev-master#8684ee4 as 1.3.x-dev",
+        "behat/mink": "dev-master#a534fe7"
     },
     "_readme": [
         "We explicitly require consolidation/robo to allow lower 'composer update --prefer-lowest' to complete successfully.",
-        "We explicitly require consolidation/annotated-command to allow lower 'composer update --prefer-lowest' to complete successfully."
+        "We explicitly require consolidation/annotated-command to allow lower 'composer update --prefer-lowest' to complete successfully.",
+        "We need to alias a specific version of 'behat/mink-selenium2-driver' to '1.3.x-dev' since this branch is not available any longer. For more information check: https://github.com/minkphp/MinkSelenium2Driver/issues/313.",
+        "Upcoming ~1.4 of 'behat/mink-selenium2-driver' is known to have issues with latest 'behat/mink', so we need to pinpoint a specific version of the latter. For more information check: https://www.drupal.org/project/drupal/issues/3078671#comment-13244409."
     ],
     "scripts": {
         "post-install-cmd": "./vendor/bin/run drupal:site-setup",

--- a/tests/Behat/AuthenticationContext.php
+++ b/tests/Behat/AuthenticationContext.php
@@ -4,7 +4,6 @@ declare(strict_types = 1);
 
 namespace Drupal\Tests\oe_authentication\Behat;
 
-use Drupal\DrupalExtension\Context\ConfigContext;
 use Drupal\user\Entity\User;
 use Behat\Behat\Hook\Scope\BeforeScenarioScope;
 use Drupal\DrupalExtension\Context\RawDrupalContext;


### PR DESCRIPTION

## OPENEUROPA-2259
### Description

 Fix behat/mink-selenium2-driver missing branch by aliasing.

### Change log

- Added:
- Changed:
- Deprecated:
- Removed:
- Fixed:  Fix behat/mink-selenium2-driver missing branch by aliasing.
- Security:

### Commands

```sh
[Insert commands here]

```

