### PR TITLE
OPENEUROPA-2699: Lock drupal/cas version to 1.5.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
     "minimum-stability": "dev",
     "prefer-stable": true,
     "require": {
-        "drupal/cas": "^1.5",
+        "drupal/cas": "1.5",
         "drupal/core": "^8.7",
         "php": "^7.1"
     },


### PR DESCRIPTION
## OPENEUROPA-2699

### Description

Lock drupal/cas version to 1.5 after release 1.6 of `drupal/cas` so that existing composer patch still applies.