### PR TITLE
OPENEUROPA-0000: Fix the drupal/cas version to 1.6.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
     "minimum-stability": "dev",
     "prefer-stable": true,
     "require": {
-        "drupal/cas": "^1.6",
+        "drupal/cas": "1.6",
         "drupal/core": "^8.7",
         "php": ">=7.2"
     },
@@ -28,6 +28,9 @@
         "symfony/browser-kit": "~3.0||~4.0",
         "symfony/dom-crawler": "~3.4"
     },
+    "_readme": [
+        "We explicitly require drupal/cas 1.6 since some service methods were deprecated. To be fixed on OPENEUROPA-3370."
+    ],
     "scripts": {
         "post-install-cmd": "./vendor/bin/run drupal:site-setup",
         "post-update-cmd": "./vendor/bin/run drupal:site-setup"


### PR DESCRIPTION
## OPENEUROPA

### Description

Fix the drupal/cas version to 1.6.

### Change log

- Added:
- Changed: Fix the drupal/cas version to 1.6.
- Deprecated:
- Removed:
- Fixed:
- Security:

### Commands

```sh
[Insert commands here]

```

