### PR TITLE
OEL-153: Prevent CAS from creating a new user account if the email is already taken.

### DIFF
--- a/behat.yml.dist
+++ b/behat.yml.dist
@@ -35,5 +35,8 @@ default:
         drupal_root: "${drupal.root}"
       selectors:
         message_selector: ".messages"
+        error_message_selector: '.messages.messages--error'
+        success_message_selector: '.messages.messages--status'
+        warning_message_selector: '.messages.messages--warning'
   formatters:
     progress: ~

--- a/composer.json
+++ b/composer.json
@@ -8,6 +8,7 @@
     "require": {
         "php": ">=7.3",
         "drupal/core": "^8.9 || ^9.1",
+        "cweagans/composer-patches": "^1.6",
         "drupal/cas": "^1.7"
     },
     "require-dev": {
@@ -53,6 +54,11 @@
             "build/profiles/contrib/{$name}": ["type:drupal-profile"],
             "build/modules/contrib/{$name}": ["type:drupal-module"],
             "build/themes/contrib/{$name}": ["type:drupal-theme"]
+        },
+        "patches": {
+            "drupal/cas": {
+                "https://www.drupal.org/project/cas/issues/3221111": "https://git.drupalcode.org/project/cas/-/merge_requests/4.patch"
+            }
         },
         "drupal-scaffold": {
             "locations": {

--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
     "require": {
         "php": ">=7.3",
         "drupal/core": "^8.9 || ^9.1",
-        "cweagans/composer-patches": "^1.6",
+        "cweagans/composer-patches": "^1.7",
         "drupal/cas": "^1.7"
     },
     "require-dev": {

--- a/src/CasProcessor.php
+++ b/src/CasProcessor.php
@@ -54,7 +54,7 @@ class CasProcessor {
     $associative = $toplevel || static::isAssociative($node);
 
     $attributes = [];
-    // @var \DOMElement $child
+    /** @var \DOMElement $child */
     foreach ($node->childNodes as $key => $child) {
       $name = $child->localName;
       // If the child has sub-levels, recursively parse the attributes

--- a/src/Event/EuLoginEventSubscriber.php
+++ b/src/Event/EuLoginEventSubscriber.php
@@ -77,7 +77,7 @@ class EuLoginEventSubscriber implements EventSubscriberInterface {
   }
 
   /**
-   * Checks user e-mail exists previously.
+   * Checks user email exists previously.
    *
    * @param \Drupal\cas\Event\CasPreRegisterEvent $event
    *   The triggered event.
@@ -87,8 +87,8 @@ class EuLoginEventSubscriber implements EventSubscriberInterface {
     if ($cas_settings->get('user_accounts.auto_register')) {
       $email = $event->getCasPropertyBag()->getAttribute('email');
 
-      if (user_load_by_mail($email) !== FALSE) {
-        $event->cancelAutomaticRegistration(t('A user with this mail already exists. Please contact with your site administrator.')->render());
+      if (user_load_by_mail($email)) {
+        $event->cancelAutomaticRegistration($this->t('A user with this mail already exists. Please contact with your site administrator.'));
         $event->stopPropagation();
       }
     }

--- a/src/Event/EuLoginEventSubscriber.php
+++ b/src/Event/EuLoginEventSubscriber.php
@@ -88,7 +88,7 @@ class EuLoginEventSubscriber implements EventSubscriberInterface {
       $email = $event->getCasPropertyBag()->getAttribute('email');
 
       if (user_load_by_mail($email)) {
-        $event->cancelAutomaticRegistration($this->t('A user with this mail already exists. Please contact with your site administrator.'));
+        $event->cancelAutomaticRegistration($this->t('A user with this email address already exists. Please contact the site administrator.'));
         $event->stopPropagation();
       }
     }

--- a/src/Event/MessengerEuLoginEventSubscriber.php
+++ b/src/Event/MessengerEuLoginEventSubscriber.php
@@ -62,6 +62,10 @@ class MessengerEuLoginEventSubscriber implements EventSubscriberInterface {
       return;
     }
 
+    if ($properties['status'] === 'error_automatic_registration') {
+      return;
+    }
+
     if (!$properties['status']) {
       $this->messenger->addStatus($this->t('Thank you for applying for an account. Your account is currently pending approval by the site administrator.'));
     }

--- a/src/Event/MessengerEuLoginEventSubscriber.php
+++ b/src/Event/MessengerEuLoginEventSubscriber.php
@@ -62,10 +62,6 @@ class MessengerEuLoginEventSubscriber implements EventSubscriberInterface {
       return;
     }
 
-    if ($properties['status'] === 'error_automatic_registration') {
-      return;
-    }
-
     if (!$properties['status']) {
       $this->messenger->addStatus($this->t('Thank you for applying for an account. Your account is currently pending approval by the site administrator.'));
     }

--- a/tests/Behat/AuthenticationContext.php
+++ b/tests/Behat/AuthenticationContext.php
@@ -129,7 +129,7 @@ class AuthenticationContext extends RawDrupalContext {
   }
 
   /**
-   * Configures the the Drupal site so that users are blocked on creation.
+   * Configures the Drupal site so that users are blocked on creation.
    *
    * @Given the site is configured to make users blocked on creation
    */
@@ -145,6 +145,32 @@ class AuthenticationContext extends RawDrupalContext {
   public function allowExternalUsers(): void {
     // Set the assurance level to allow also external users to login.
     $this->configContext->setConfig('oe_authentication.settings', 'assurance_level', 'LOW');
+  }
+
+  /**
+   * Configures the CAS server so users are created in login if not exists.
+   *
+   * @Given the site is configured to register users if not exists
+   */
+  public function theSiteIsConfiguredToRegisterUsersIfNotExists(): void {
+    $this->configContext->setConfig('user_accounts.auto_register', 'cas.settings', TRUE);
+  }
+
+  /**
+   * Create a local user.
+   *
+   * @Given a user with the same email already exists locally
+   */
+  public function createLocalUser(): void {
+    $edit = [
+      'name' => 'james',
+      'mail' => '007@mi6.eu',
+      'pass' => 'haken_not_stirred',
+      'status' => 1,
+    ];
+
+    $account = User::create($edit);
+    $account->save();
   }
 
 }

--- a/tests/Behat/AuthenticationContext.php
+++ b/tests/Behat/AuthenticationContext.php
@@ -147,30 +147,4 @@ class AuthenticationContext extends RawDrupalContext {
     $this->configContext->setConfig('oe_authentication.settings', 'assurance_level', 'LOW');
   }
 
-  /**
-   * Configures the CAS server so users are created in login if not exists.
-   *
-   * @Given the site is configured to register users if not exists
-   */
-  public function theSiteIsConfiguredToRegisterUsersIfNotExists(): void {
-    $this->configContext->setConfig('user_accounts.auto_register', 'cas.settings', TRUE);
-  }
-
-  /**
-   * Create a local user.
-   *
-   * @Given a user with the same email already exists locally
-   */
-  public function createLocalUser(): void {
-    $edit = [
-      'name' => 'james',
-      'mail' => '007@mi6.eu',
-      'pass' => 'haken_not_stirred',
-      'status' => 1,
-    ];
-
-    $account = User::create($edit);
-    $account->save();
-  }
-
 }

--- a/tests/features/ecas-login.feature
+++ b/tests/features/ecas-login.feature
@@ -149,3 +149,19 @@ Feature: Login through OE Authentication
     And I should see "Your account is blocked or has not been activated. Please contact a site administrator."
     And I should see "Thank you for applying for an account. Your account is currently pending approval by the site administrator."
     And I should see the link "Log in"
+
+  @cleanup:user
+  Scenario: Login user with an already registered email with auto-register enabled
+    Given users:
+      | name    | mail        |
+      | james   | 007@mi6.eu  |
+    And I am an anonymous user
+    When I am on the homepage
+    And I click "Log in"
+    # Redirected to the mock server.
+    And I fill in "Username or e-mail address" with "007@mi6.eu"
+    And I fill in "Password" with "shaken_not_stirred"
+    And I press the "Login!" button
+    # Redirected back to Drupal.
+    Then I should see the error message "A user with this email address already exists. Please contact the site administrator."
+    And I should see the link "Log in"

--- a/tests/features/ecas-register.feature
+++ b/tests/features/ecas-register.feature
@@ -13,10 +13,10 @@ Feature: Register through OE Authentication
 
   @cleanup:user
   Scenario: Login user with auto-register enabled
-    Given I am an anonymous user
     Given CAS users:
       | Username    | E-mail                            | Password           | First name | Last name | Department    | Organisation |
       | jb007       | 007@mi6.eu                        | shaken_not_stirred | James      | Bond      | DIGIT.A.3.001 | external     |
+    And I am an anonymous user
     When I am on the homepage
     And I click "Log in"
     # Redirected to the mock server.
@@ -24,20 +24,18 @@ Feature: Register through OE Authentication
     And I fill in "Password" with "shaken_not_stirred"
     And I press the "Login!" button
     # Redirected back to Drupal.
-    Then I should see "Your account is currently pending approval by the site administrator."
+    Then I should see the success message "Your account is currently pending approval by the site administrator."
     And I should see the link "Log in"
 
   @cleanup:user
   Scenario: Login user with an already registered email with auto-register enabled
-    Given I am an anonymous user
     Given users:
       | name    | mail        |
       | james   | 007@mi6.eu  |
-
-    Given CAS users:
+    And CAS users:
       | Username    | E-mail         | Password           | First name | Last name | Department    | Organisation |
       | jb007       | 007@mi6.eu     | shaken_not_stirred | James      | Bond      | DIGIT.A.3.001 | external     |
-
+    And I am an anonymous user
     When I am on the homepage
     And I click "Log in"
     # Redirected to the mock server.

--- a/tests/features/ecas-register.feature
+++ b/tests/features/ecas-register.feature
@@ -1,11 +1,44 @@
+@api @casMockServer
 Feature: Register through OE Authentication
   In order to be able to have new users
   As an anonymous user of the system
   I need to be able to go to the registration URL
 
+  Background:
+    Given CAS users:
+      | Username    | E-mail                            | Password           | First name | Last name | Department    | Organisation |
+      | jb007       | 007@mi6.eu                        | shaken_not_stirred | James      | Bond      | DIGIT.A.3.001 | external     |
+
   Scenario: Register
     Given I am an anonymous user
-    When I visit "the user registration page"
+    When I visit "cas-mock-server/eim/external/register.cgi"
     # Redirected to the Ecas mockup server.
     Then I should see "Create an account"
     And I should see "This page is part of the EU login mock."
+
+  @cleanup:user
+  Scenario: Register new user with AutoRegister enabled
+    Given the site is configured to register users if not exists
+    When I am on the homepage
+    And I click "Log in"
+    # Redirected to the mock server.
+    And I fill in "Username or e-mail address" with "007@mi6.eu"
+    And I fill in "Password" with "shaken_not_stirred"
+    And I press the "Login!" button
+    # Redirected back to Drupal.
+    Then I should see "Your account is currently pending approval by the site administrator."
+    And I should see the link "Log in"
+
+  @cleanup:user
+  Scenario: Register with AutoRegister enabled a user with already existent e-mail
+    Given the site is configured to register users if not exists
+    Given a user with the same email already exists locally
+    When I am on the homepage
+    And I click "Log in"
+    # Redirected to the mock server.
+    And I fill in "Username or e-mail address" with "007@mi6.eu"
+    And I fill in "Password" with "shaken_not_stirred"
+    And I press the "Login!" button
+    # Redirected back to Drupal.
+    Then I should see "A user with this mail already exists. Please contact with your site administrator."
+    And I should see the link "Log in"

--- a/tests/features/ecas-register.feature
+++ b/tests/features/ecas-register.feature
@@ -10,38 +10,3 @@ Feature: Register through OE Authentication
     # Redirected to the Ecas mockup server.
     Then I should see "Create an account"
     And I should see "This page is part of the EU login mock."
-
-  @cleanup:user
-  Scenario: Login user with auto-register enabled
-    Given CAS users:
-      | Username    | E-mail                            | Password           | First name | Last name | Department    | Organisation |
-      | jb007       | 007@mi6.eu                        | shaken_not_stirred | James      | Bond      | DIGIT.A.3.001 | external     |
-    And I am an anonymous user
-    When I am on the homepage
-    And I click "Log in"
-    # Redirected to the mock server.
-    And I fill in "Username or e-mail address" with "007@mi6.eu"
-    And I fill in "Password" with "shaken_not_stirred"
-    And I press the "Login!" button
-    # Redirected back to Drupal.
-    Then I should see the success message "Your account is currently pending approval by the site administrator."
-    And I should see the link "Log in"
-
-  @cleanup:user
-  Scenario: Login user with an already registered email with auto-register enabled
-    Given users:
-      | name    | mail        |
-      | james   | 007@mi6.eu  |
-    And CAS users:
-      | Username    | E-mail         | Password           | First name | Last name | Department    | Organisation |
-      | jb007       | 007@mi6.eu     | shaken_not_stirred | James      | Bond      | DIGIT.A.3.001 | external     |
-    And I am an anonymous user
-    When I am on the homepage
-    And I click "Log in"
-    # Redirected to the mock server.
-    And I fill in "Username or e-mail address" with "007@mi6.eu"
-    And I fill in "Password" with "shaken_not_stirred"
-    And I press the "Login!" button
-    # Redirected back to Drupal.
-    Then I should see the error message "A user with this email address already exists. Please contact the site administrator."
-    And I should see the link "Log in"

--- a/tests/features/ecas-register.feature
+++ b/tests/features/ecas-register.feature
@@ -43,5 +43,5 @@ Feature: Register through OE Authentication
     And I fill in "Password" with "shaken_not_stirred"
     And I press the "Login!" button
     # Redirected back to Drupal.
-    Then I should see the error message "A user with this mail already exists. Please contact with your site administrator."
+    Then I should see the error message "A user with this email address already exists. Please contact the site administrator."
     And I should see the link "Log in"

--- a/tests/features/ecas-register.feature
+++ b/tests/features/ecas-register.feature
@@ -4,21 +4,19 @@ Feature: Register through OE Authentication
   As an anonymous user of the system
   I need to be able to go to the registration URL
 
-  Background:
-    Given CAS users:
-      | Username    | E-mail                            | Password           | First name | Last name | Department    | Organisation |
-      | jb007       | 007@mi6.eu                        | shaken_not_stirred | James      | Bond      | DIGIT.A.3.001 | external     |
-
   Scenario: Register
     Given I am an anonymous user
-    When I visit "cas-mock-server/eim/external/register.cgi"
+    When I visit "the user registration page"
     # Redirected to the Ecas mockup server.
     Then I should see "Create an account"
     And I should see "This page is part of the EU login mock."
 
   @cleanup:user
-  Scenario: Register new user with AutoRegister enabled
-    Given the site is configured to register users if not exists
+  Scenario: Login user with auto-register enabled
+    Given I am an anonymous user
+    Given CAS users:
+      | Username    | E-mail                            | Password           | First name | Last name | Department    | Organisation |
+      | jb007       | 007@mi6.eu                        | shaken_not_stirred | James      | Bond      | DIGIT.A.3.001 | external     |
     When I am on the homepage
     And I click "Log in"
     # Redirected to the mock server.
@@ -30,9 +28,16 @@ Feature: Register through OE Authentication
     And I should see the link "Log in"
 
   @cleanup:user
-  Scenario: Register with AutoRegister enabled a user with already existent e-mail
-    Given the site is configured to register users if not exists
-    Given a user with the same email already exists locally
+  Scenario: Login user with an already registered email with auto-register enabled
+    Given I am an anonymous user
+    Given users:
+      | name    | mail        |
+      | james   | 007@mi6.eu  |
+
+    Given CAS users:
+      | Username    | E-mail         | Password           | First name | Last name | Department    | Organisation |
+      | jb007       | 007@mi6.eu     | shaken_not_stirred | James      | Bond      | DIGIT.A.3.001 | external     |
+
     When I am on the homepage
     And I click "Log in"
     # Redirected to the mock server.
@@ -40,5 +45,5 @@ Feature: Register through OE Authentication
     And I fill in "Password" with "shaken_not_stirred"
     And I press the "Login!" button
     # Redirected back to Drupal.
-    Then I should see "A user with this mail already exists. Please contact with your site administrator."
+    Then I should see the error message "A user with this mail already exists. Please contact with your site administrator."
     And I should see the link "Log in"


### PR DESCRIPTION
## OPENEUROPA-153

### Description

Not allow to register a user from CAS if a user with the same email exists locally. Inform of this error with a friendly message.

### Change log

- Added: 
- Changed: Modifications to an already subscribed events
- Deprecated:
- Removed:
- Fixed:
- Security:

### Commands

```sh
[Insert commands here]

```

