### PR TITLE
OE-AUTH-01: Sanitize users one by one instead of loading them in bulk…

### DIFF
--- a/modules/oe_authentication_user_fields/src/Commands/sql/UserSanitizeCommand.php
+++ b/modules/oe_authentication_user_fields/src/Commands/sql/UserSanitizeCommand.php
@@ -49,6 +49,7 @@ class UserSanitizeCommand extends DrushCommands implements SanitizePluginInterfa
     $user_ids = $user_storage->getQuery()->execute();
 
     foreach ($user_ids as $uid) {
+      /** @var \Drupal\user\Entity\User $user */
       $user = $user_storage->load($uid);
       $user->set('field_oe_firstname', 'First Name ' . $user->id());
       $user->set('field_oe_lastname', 'Last Name ' . $user->id());

--- a/modules/oe_authentication_user_fields/src/Commands/sql/UserSanitizeCommand.php
+++ b/modules/oe_authentication_user_fields/src/Commands/sql/UserSanitizeCommand.php
@@ -41,9 +41,15 @@ class UserSanitizeCommand extends DrushCommands implements SanitizePluginInterfa
    * @inheritdoc
    */
   public function sanitize($result, CommandData $commandData) {
-    /** @var \Drupal\user\Entity\User[] $users */
-    $users = $this->entityTypeManager->getStorage('user')->loadMultiple();
-    foreach ($users as $user) {
+
+    /** @var  \Drupal\Core\Entity\EntityTypeManagerInterface $user_storage */
+    $user_storage = $this->entityTypeManager->getStorage('user');
+
+    /** @var int[] $user_ids */
+    $user_ids = $user_storage->getQuery()->execute();
+
+    foreach ($user_ids as $uid) {
+      $user = $user_storage->load($uid);
       $user->set('field_oe_firstname', 'First Name ' . $user->id());
       $user->set('field_oe_lastname', 'Last Name ' . $user->id());
       $user->set('field_oe_department', 'Department ' . $user->id());


### PR DESCRIPTION
… (memory consumption issue).

## OPENEUROPA-[Insert ticket number here]

### Description

On sites with a big number of users (100K+), the user Drush sanitization function from the oe_authentication_user_fields module is trying to load the entire list of users in memory before sanitizating them and that, in turn, depending on the PHP CLI ram limits, might trigger an Out of memory error.

Issue triggered by this: https://citnet.tech.ec.europa.eu/CITnet/jira/browse/FPFISSUPP-16923

### Change log

- Added:
- **Changed**: Changed the users loading to a one by one basis in order to not generate an Out of memory error.
- Deprecated:
- Removed:
- Fixed:
- Security:
