### PR TITLE
EWPP-2210: Optimize query for sanitizing of user data.

### DIFF
--- a/modules/oe_authentication_user_fields/oe_authentication_user_fields.services.yml
+++ b/modules/oe_authentication_user_fields/oe_authentication_user_fields.services.yml
@@ -5,6 +5,6 @@ services:
       - { name: event_subscriber }
   oe_authentication_user_fields.sanitize_commands:
     class: Drupal\oe_authentication_user_fields\Commands\sql\UserSanitizeCommand
-    arguments: ['@entity_type.manager']
+    arguments: ['@entity_type.manager', '@database']
     tags:
       -  { name: drush.command }

--- a/modules/oe_authentication_user_fields/tests/src/Functional/UserSanitizeCommandTest.php
+++ b/modules/oe_authentication_user_fields/tests/src/Functional/UserSanitizeCommandTest.php
@@ -31,10 +31,17 @@ class UserSanitizeCommandTest extends BrowserTestBase {
    */
   public function testEuLoginUsersDataSanitization() {
     $user = $this->createUser([], NULL, FALSE, [
-      'field_oe_firstname' => 'First name',
-      'field_oe_lastname' => 'Last name',
-      'field_oe_department' => 'Department',
-      'field_oe_organisation' => 'Organisation',
+      'field_oe_firstname' => 'Laurissa',
+      'field_oe_lastname' => 'Garrett',
+      'field_oe_department' => 'Needless',
+      'field_oe_organisation' => 'Beam',
+    ]);
+
+    $user2 = $this->createUser([], NULL, FALSE, [
+      'field_oe_firstname' => 'Beverly',
+      'field_oe_lastname' => 'Thorley',
+      'field_oe_department' => 'Green',
+      'field_oe_organisation' => 'Lantern',
     ]);
 
     $this->drush('sql:sanitize');
@@ -51,6 +58,12 @@ class UserSanitizeCommandTest extends BrowserTestBase {
     $this->assertEquals('Last Name ' . $user->id(), $user->get('field_oe_lastname')->value);
     $this->assertEquals('Department ' . $user->id(), $user->get('field_oe_department')->value);
     $this->assertEquals('Organisation ' . $user->id(), $user->get('field_oe_organisation')->value);
+
+    $user2 = \Drupal::entityTypeManager()->getStorage('user')->load($user2->id());
+    $this->assertEquals('First Name ' . $user2->id(), $user2->get('field_oe_firstname')->value);
+    $this->assertEquals('Last Name ' . $user2->id(), $user2->get('field_oe_lastname')->value);
+    $this->assertEquals('Department ' . $user2->id(), $user2->get('field_oe_department')->value);
+    $this->assertEquals('Organisation ' . $user2->id(), $user2->get('field_oe_organisation')->value);
   }
 
 }


### PR DESCRIPTION
## OPENEUROPA-EWPP-2210

### Description

On one of the sites (Epale – from EACEA) the sanitization led to memory issues and following further investigation the problem was pinpointed to the new sanitization in oe_authentication (see https://github.com/openeuropa/oe_authentication/commit/e3ca1f5527c10363db010b39d8950b778aab89cb). The problem is that the code implemented is loading in memory all users in a single go as objects and therefore the memory needed depends linearly on the number of users. For a large site such as EPALE (~130K users) this leads to more than 5GB RAM needed for the sanitization. Furthermore, the sanitization is done one by one which requires a very long time.

Related Github issue: https://github.com/openeuropa/oe_authentication/issues/152

### Change log

- Added:
- Changed: \Drupal\oe_authentication_user_fields\Commands\sql\UserSanitizeCommand, \Drupal\Tests\oe_authentication_user_fields\Functional\UserSanitizeCommandTest
- Deprecated:
- Removed:
- Fixed:
- Security:

### Commands

```sh
[Insert commands here]

```

