### PR TITLE
OPES-1547: Apply configured conditions on user login

### DIFF
--- a/modules/oe_authentication_corporate_roles/tests/src/Kernel/CorporateRolesTest.php
+++ b/modules/oe_authentication_corporate_roles/tests/src/Kernel/CorporateRolesTest.php
@@ -22,6 +22,8 @@ class CorporateRolesTest extends KernelTestBase {
    * {@inheritdoc}
    */
   protected static $modules = [
+    'cas',
+    'externalauth',
     'oe_authentication',
     'oe_authentication_corporate_roles',
     'oe_authentication_user_fields',

--- a/oe_authentication.services.yml
+++ b/oe_authentication.services.yml
@@ -13,3 +13,16 @@ services:
     tags:
       - { name: event_subscriber }
     arguments: ['@messenger']
+  oe_authentication.subscriber.two_factor_authentication:
+    class: Drupal\oe_authentication\Event\TwoFactorAuthenticationEventSubscriber
+    arguments:
+      - '@config.factory'
+      - '@plugin.manager.condition'
+      - '@context.handler'
+      - '@logger.channel.oe_authentication'
+      - '@cas.helper'
+    tags:
+      - { name: event_subscriber }
+  logger.channel.oe_authentication:
+    parent: logger.channel_base
+    arguments: ['oe_authentication']

--- a/oe_authentication.services.yml
+++ b/oe_authentication.services.yml
@@ -1,15 +1,15 @@
 services:
   oe_authentication.route_subscriber:
-    class: \Drupal\oe_authentication\Routing\RouteSubscriber
+    class: Drupal\oe_authentication\Routing\RouteSubscriber
     tags:
       - { name: event_subscriber }
   oe_authentication.event_subscriber:
-    class: \Drupal\oe_authentication\Event\EuLoginEventSubscriber
+    class: Drupal\oe_authentication\Event\EuLoginEventSubscriber
     tags:
       - { name: event_subscriber }
     arguments: ['@config.factory']
   oe_authentication.messenger.event_subscriber:
-    class: \Drupal\oe_authentication\Event\MessengerEuLoginEventSubscriber
+    class: Drupal\oe_authentication\Event\MessengerEuLoginEventSubscriber
     tags:
       - { name: event_subscriber }
     arguments: ['@messenger']

--- a/oe_authentication.services.yml
+++ b/oe_authentication.services.yml
@@ -21,6 +21,7 @@ services:
       - '@context.handler'
       - '@logger.channel.oe_authentication'
       - '@cas.helper'
+      - '@string_translation'
     tags:
       - { name: event_subscriber }
   logger.channel.oe_authentication:

--- a/runner.yml.dist
+++ b/runner.yml.dist
@@ -47,5 +47,7 @@ commands:
     - { task: "run", command: "setup:behat" }
   setup:phpunit:
     - { task: "process", source: "phpunit.xml.dist", destination: "phpunit.xml" }
+    # Generate settings.testing.php, it will be used when running functional tests.
+    - { task: "process-php", type: "write", config: "drupal.settings", source: "${drupal.root}/sites/default/default.settings.php", destination: "${drupal.root}/sites/default/settings.testing.php", override: true }
   setup:behat:
     - { task: "process", source: "behat.yml.dist", destination: "behat.yml" }

--- a/src/Event/TwoFactorAuthenticationEventSubscriber.php
+++ b/src/Event/TwoFactorAuthenticationEventSubscriber.php
@@ -11,7 +11,6 @@ use Drupal\Core\Executable\ExecutableManagerInterface;
 use Drupal\Core\Plugin\Context\ContextHandlerInterface;
 use Drupal\Core\Plugin\Context\EntityContext;
 use Drupal\Core\Plugin\ContextAwarePluginInterface;
-use Drupal\Core\Plugin\FilteredPluginManagerInterface;
 use Drupal\Core\StringTranslation\StringTranslationTrait;
 use Drupal\Core\Utility\Error;
 use Psr\Log\LoggerInterface;
@@ -29,7 +28,7 @@ class TwoFactorAuthenticationEventSubscriber implements EventSubscriberInterface
    *
    * @param \Drupal\Core\Config\ConfigFactoryInterface $configFactory
    *   The config factory.
-   * @param \Drupal\Core\Executable\ExecutableManagerInterface&\Drupal\Core\Plugin\FilteredPluginManagerInterface $conditionManager
+   * @param \Drupal\Core\Executable\ExecutableManagerInterface $conditionManager
    *   The condition manager.
    * @param \Drupal\Core\Plugin\Context\ContextHandlerInterface $contextHandler
    *   The context handler.
@@ -40,7 +39,7 @@ class TwoFactorAuthenticationEventSubscriber implements EventSubscriberInterface
    */
   public function __construct(
     protected ConfigFactoryInterface $configFactory,
-    protected ExecutableManagerInterface&FilteredPluginManagerInterface $conditionManager,
+    protected ExecutableManagerInterface $conditionManager,
     protected ContextHandlerInterface $contextHandler,
     protected LoggerInterface $logger,
     protected CasHelper $casHelper,

--- a/src/Event/TwoFactorAuthenticationEventSubscriber.php
+++ b/src/Event/TwoFactorAuthenticationEventSubscriber.php
@@ -38,11 +38,11 @@ class TwoFactorAuthenticationEventSubscriber implements EventSubscriberInterface
    *   The CAS helper service.
    */
   public function __construct(
-    protected ConfigFactoryInterface $configFactory,
-    protected ExecutableManagerInterface $conditionManager,
-    protected ContextHandlerInterface $contextHandler,
-    protected LoggerInterface $logger,
-    protected CasHelper $casHelper,
+    protected readonly ConfigFactoryInterface $configFactory,
+    protected readonly ExecutableManagerInterface $conditionManager,
+    protected readonly ContextHandlerInterface $contextHandler,
+    protected readonly LoggerInterface $logger,
+    protected readonly CasHelper $casHelper,
   ) {}
 
   /**

--- a/src/Event/TwoFactorAuthenticationEventSubscriber.php
+++ b/src/Event/TwoFactorAuthenticationEventSubscriber.php
@@ -23,20 +23,6 @@ class TwoFactorAuthenticationEventSubscriber implements EventSubscriberInterface
 
   use StringTranslationTrait;
 
-  /**
-   * Creates a new instance of this class.
-   *
-   * @param \Drupal\Core\Config\ConfigFactoryInterface $configFactory
-   *   The config factory.
-   * @param \Drupal\Core\Executable\ExecutableManagerInterface $conditionManager
-   *   The condition manager.
-   * @param \Drupal\Core\Plugin\Context\ContextHandlerInterface $contextHandler
-   *   The context handler.
-   * @param \Psr\Log\LoggerInterface $logger
-   *   The logger for oe_authentication.
-   * @param \Drupal\cas\Service\CasHelper $casHelper
-   *   The CAS helper service.
-   */
   public function __construct(
     protected readonly ConfigFactoryInterface $configFactory,
     protected readonly ExecutableManagerInterface $conditionManager,

--- a/src/Event/TwoFactorAuthenticationEventSubscriber.php
+++ b/src/Event/TwoFactorAuthenticationEventSubscriber.php
@@ -69,16 +69,18 @@ class TwoFactorAuthenticationEventSubscriber implements EventSubscriberInterface
     }
 
     $config = $this->configFactory->get('oe_authentication.settings');
-    // If forced 2FA is disabled, there is no extra validation needed.
-    if (!$config->get('force_2fa')) {
+    // If 2FA is set to be enforced for all users, it should have been applied
+    // already on EU Login side. But something happened, and it wasn't applied
+    // to this login attempt.
+    if ($config->get('force_2fa')) {
+      $event->cancelLogin($this->t('You are required to log in using a two-factor authentication method.'));
       return;
     }
 
     $conditions_configuration = $config->get('2fa_conditions');
-    // If no conditions are present, the 2FA should have been enforced on EU
-    // Login side, but didn't happen.
+    // If no conditions are present, all users can freely log in with any
+    // method.
     if (empty($conditions_configuration)) {
-      $event->cancelLogin($this->t('You are required to log in using a two-factor authentication method.'));
       return;
     }
 

--- a/src/Event/TwoFactorAuthenticationEventSubscriber.php
+++ b/src/Event/TwoFactorAuthenticationEventSubscriber.php
@@ -12,6 +12,7 @@ use Drupal\Core\Plugin\Context\ContextHandlerInterface;
 use Drupal\Core\Plugin\Context\EntityContext;
 use Drupal\Core\Plugin\ContextAwarePluginInterface;
 use Drupal\Core\StringTranslation\StringTranslationTrait;
+use Drupal\Core\StringTranslation\TranslationInterface;
 use Drupal\Core\Utility\Error;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
@@ -29,7 +30,10 @@ class TwoFactorAuthenticationEventSubscriber implements EventSubscriberInterface
     protected readonly ContextHandlerInterface $contextHandler,
     protected readonly LoggerInterface $logger,
     protected readonly CasHelper $casHelper,
-  ) {}
+    TranslationInterface $stringTranslation,
+  ) {
+    $this->stringTranslation = $stringTranslation;
+  }
 
   /**
    * {@inheritdoc}

--- a/src/Event/TwoFactorAuthenticationEventSubscriber.php
+++ b/src/Event/TwoFactorAuthenticationEventSubscriber.php
@@ -73,14 +73,14 @@ class TwoFactorAuthenticationEventSubscriber implements EventSubscriberInterface
   }
 
   /**
-   * Evaluates the configured conditions.
+   * Cancels the login if any of the configured conditions matches.
    *
    * @param \Drupal\cas\Event\CasPreLoginEvent $event
    *   The pre-login event.
-   * @param mixed $conditions_configuration
+   * @param array[] $conditions_configuration
    *   The conditions' configuration.
    */
-  protected function evaluateConditions(CasPreLoginEvent $event, mixed $conditions_configuration): void {
+  protected function evaluateConditions(CasPreLoginEvent $event, array $conditions_configuration): void {
     $contexts = [
       'user' => EntityContext::fromEntity($event->getAccount()),
     ];
@@ -120,10 +120,10 @@ class TwoFactorAuthenticationEventSubscriber implements EventSubscriberInterface
    *   True if 2FA has been used, false otherwise.
    */
   protected function isLoginWithTwoFactorAuthentication(CasPreLoginEvent $event): bool {
-    return in_array($event->getCasPropertyBag()->getAttribute('authenticationLevel'), [
-      'MEDIUM',
-      'HIGH',
-    ]);
+    return in_array(
+      $event->getCasPropertyBag()->getAttribute('authenticationLevel'),
+      ['MEDIUM', 'HIGH'],
+    );
   }
 
 }

--- a/src/Event/TwoFactorAuthenticationEventSubscriber.php
+++ b/src/Event/TwoFactorAuthenticationEventSubscriber.php
@@ -1,0 +1,134 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\oe_authentication\Event;
+
+use Drupal\cas\Event\CasPreLoginEvent;
+use Drupal\cas\Service\CasHelper;
+use Drupal\Core\Config\ConfigFactoryInterface;
+use Drupal\Core\Executable\ExecutableManagerInterface;
+use Drupal\Core\Plugin\Context\ContextHandlerInterface;
+use Drupal\Core\Plugin\Context\EntityContext;
+use Drupal\Core\Plugin\ContextAwarePluginInterface;
+use Drupal\Core\Plugin\FilteredPluginManagerInterface;
+use Drupal\Core\StringTranslation\StringTranslationTrait;
+use Drupal\Core\Utility\Error;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+/**
+ * Event subscriber that handles two-factor authentication conditions.
+ */
+class TwoFactorAuthenticationEventSubscriber implements EventSubscriberInterface {
+
+  use StringTranslationTrait;
+
+  /**
+   * Creates a new instance of this class.
+   *
+   * @param \Drupal\Core\Config\ConfigFactoryInterface $configFactory
+   *   The config factory.
+   * @param \Drupal\Core\Executable\ExecutableManagerInterface&\Drupal\Core\Plugin\FilteredPluginManagerInterface $conditionManager
+   *   The condition manager.
+   * @param \Drupal\Core\Plugin\Context\ContextHandlerInterface $contextHandler
+   *   The context handler.
+   * @param \Psr\Log\LoggerInterface $logger
+   *   The logger for oe_authentication.
+   * @param \Drupal\cas\Service\CasHelper $casHelper
+   *   The CAS helper service.
+   */
+  public function __construct(
+    protected ConfigFactoryInterface $configFactory,
+    protected ExecutableManagerInterface&FilteredPluginManagerInterface $conditionManager,
+    protected ContextHandlerInterface $contextHandler,
+    protected LoggerInterface $logger,
+    protected CasHelper $casHelper,
+  ) {}
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function getSubscribedEvents() {
+    return [
+      CasPreLoginEvent::class => 'checkTwoFactorAuthentication',
+    ];
+  }
+
+  /**
+   * Checks if two-factor authentication is required and used for the login.
+   *
+   * @param \Drupal\cas\Event\CasPreLoginEvent $event
+   *   The pre-login event.
+   */
+  public function checkTwoFactorAuthentication(CasPreLoginEvent $event) {
+    // If the login has been executed with a two-factor authentication method,
+    // there is no need for further checks.
+    if ($this->isLoginWithTwoFactorAuthentication($event)) {
+      return;
+    }
+
+    $config = $this->configFactory->get('oe_authentication.settings');
+    $conditions_configuration = $config->get('2fa_conditions');
+    // If 2FA is enabled and conditions are specified, evaluate if the login
+    // requires 2FA.
+    if ($config->get('force_2fa') && !empty($conditions_configuration)) {
+      $this->evaluateConditions($event, $conditions_configuration);
+    }
+  }
+
+  /**
+   * Evaluates the configured conditions.
+   *
+   * @param \Drupal\cas\Event\CasPreLoginEvent $event
+   *   The pre-login event.
+   * @param mixed $conditions_configuration
+   *   The conditions' configuration.
+   */
+  protected function evaluateConditions(CasPreLoginEvent $event, mixed $conditions_configuration): void {
+    $contexts = [
+      'user' => EntityContext::fromEntity($event->getAccount()),
+    ];
+
+    foreach ($conditions_configuration as $id => $configuration) {
+      try {
+        /** @var \Drupal\Core\Condition\ConditionInterface $plugin */
+        $plugin = $this->conditionManager->createInstance($id, $configuration);
+        if ($plugin instanceof ContextAwarePluginInterface) {
+          $this->contextHandler->applyContextMapping($plugin, $contexts);
+        }
+
+        // Reject the login as soon as a condition plugin matches the user
+        // account.
+        if ($this->conditionManager->execute($plugin)) {
+          $event->cancelLogin($this->t('You are required to log in using a two-factor authentication method.'));
+          break;
+        }
+      }
+      catch (\Throwable $exception) {
+        // If any exception happens, we cannot trust the login attempt anymore.
+        // Use the default error message from the CAS module.
+        Error::logException($this->logger, $exception);
+        $event->cancelLogin($this->casHelper->getMessage('error_handling.message_validation_failure'));
+        break;
+      }
+    }
+  }
+
+  /**
+   * Checks if the login has been executed with a two-factor authentication.
+   *
+   * @param \Drupal\cas\Event\CasPreLoginEvent $event
+   *   The pre-login event.
+   *
+   * @return bool
+   *   True if 2FA has been used, false otherwise.
+   */
+  protected function isLoginWithTwoFactorAuthentication(CasPreLoginEvent $event): bool {
+    return in_array($event->getCasPropertyBag()->getAttribute('authenticationLevel'), [
+      'MEDIUM',
+      'HIGH',
+    ]);
+  }
+
+}

--- a/src/Event/TwoFactorAuthenticationEventSubscriber.php
+++ b/src/Event/TwoFactorAuthenticationEventSubscriber.php
@@ -61,8 +61,17 @@ class TwoFactorAuthenticationEventSubscriber implements EventSubscriberInterface
     // If 2FA is set to be enforced for all users, it should have been applied
     // already on EU Login side. But something happened, and it wasn't applied
     // to this login attempt.
+    // This has not been enforced in the past, and we cannot change this
+    // behaviour in a minor.
+    // @todo In the next major, consider cancelling the login altogether.
     if ($config->get('force_2fa')) {
-      $event->cancelLogin($this->t('You are required to log in using a two-factor authentication method.'));
+      $this->logger->warning(
+        $this->t('Two-factor authentication is enforced, but user @uid was logged in without 2FA (authenticationLevel: %level)',
+          [
+            '@uid' => $event->getAccount()->id(),
+            '%level' => $event->getCasPropertyBag()->getAttribute('authenticationLevel') ?? 'NULL',
+          ],
+        ));
       return;
     }
 

--- a/src/Form/AuthenticationSettingsForm.php
+++ b/src/Form/AuthenticationSettingsForm.php
@@ -109,11 +109,11 @@ class AuthenticationSettingsForm extends ConfigFormBase {
     $form['condition_tabs'] = [
       '#type' => 'vertical_tabs',
       '#title' => $this->t('Two-factor authentication conditions'),
-      '#description' => $this->t('Two-factor authentication will be required to log in <strong>only if at least one condition</strong> successfully matches the account that is attempting to log in. Conditions apply only if two-factor authentication is enabled.'),
+      '#description' => $this->t('Two-factor authentication will be required to log in <strong>only if at least one condition</strong> successfully matches the account that is attempting to log in. Conditions apply only if two-factor authentication is <strong>NOT</strong> enabled.'),
       '#parents' => ['condition_tabs'],
       '#states' => [
         'visible' => [
-          ':input[name="force_2fa"]' => ['checked' => TRUE],
+          ':input[name="force_2fa"]' => ['checked' => FALSE],
         ],
       ],
     ];
@@ -188,7 +188,7 @@ class AuthenticationSettingsForm extends ConfigFormBase {
       ->set('ticket_types', $form_state->getValue('ticket_types'))
       ->set('force_2fa', $force_2fa)
       // If 2FA is disabled, clear up any existing condition configuration.
-      ->set('2fa_conditions', $force_2fa ? $this->collect2FaConditionsConfiguration($form, $form_state) : [])
+      ->set('2fa_conditions', $force_2fa ? [] : $this->collect2FaConditionsConfiguration($form, $form_state))
       ->save();
 
     parent::submitForm($form, $form_state);

--- a/tests/Functional/SettingsFormTest.php
+++ b/tests/Functional/SettingsFormTest.php
@@ -54,9 +54,9 @@ class SettingsFormTest extends BrowserTestBase {
       $user_role_condition_wrapper->findAll('css', 'input[name^="2fa_conditions[user_role][roles]"]'),
     ));
 
-    // 2FA setting needs to be enabled or condition configuration won't be
+    // 2FA setting needs to be disabled or condition configuration won't be
     // saved.
-    $assert_session->fieldExists('Force two factor authentication')->check();
+    $assert_session->fieldExists('Force two factor authentication')->uncheck();
 
     // Test that validation is trigger for plugin forms.
     $test_condition_wrapper->checkField('Do not click this');
@@ -119,8 +119,8 @@ class SettingsFormTest extends BrowserTestBase {
     $assert_session->checkboxChecked('Authenticated user', $user_role_condition_wrapper);
     $assert_session->checkboxNotChecked('Negate', $user_role_condition_wrapper);
 
-    // Disabling the 2FA will clean all the condition settings.
-    $assert_session->fieldExists('Force two factor authentication')->uncheck();
+    // Enabling the 2FA will clean all the condition settings.
+    $assert_session->fieldExists('Force two factor authentication')->check();
     $assert_session->buttonExists('Save configuration')->press();
     $assert_session->statusMessageContains('The configuration options have been saved.', 'status');
     $this->refreshVariables();

--- a/tests/Functional/SettingsFormTest.php
+++ b/tests/Functional/SettingsFormTest.php
@@ -42,7 +42,7 @@ class SettingsFormTest extends BrowserTestBase {
     [$test_condition_wrapper, $user_role_condition_wrapper] = $details;
     // The first condition plugin is the user test one.
     $this->assertEquals('User test condition', $assert_session->elementExists('css', 'summary', $test_condition_wrapper)->getText());
-    $this->assertFalse($assert_session->fieldExists('Enabled', $test_condition_wrapper)->isChecked());
+    $this->assertFalse($assert_session->fieldExists('Example configuration option', $test_condition_wrapper)->isChecked());
     // The second one is the user role core plugin.
     $this->assertEquals('User Role', $assert_session->elementExists('css', 'summary', $user_role_condition_wrapper)->getText());
     $this->assertEquals([
@@ -75,7 +75,7 @@ class SettingsFormTest extends BrowserTestBase {
 
     // Set some configuration for the test plugin.
     $this->drupalGet('/admin/config/system/oe_authentication');
-    $test_condition_wrapper->checkField('Enabled');
+    $test_condition_wrapper->checkField('Example configuration option');
     $test_condition_wrapper->checkField('Negate');
     $assert_session->buttonExists('Save configuration')->press();
     $assert_session->statusMessageContains('The configuration options have been saved.', 'status');
@@ -84,7 +84,7 @@ class SettingsFormTest extends BrowserTestBase {
     $config = \Drupal::config(AuthenticationSettingsForm::CONFIG_NAME);
     $this->assertEquals([
       'oe_authentication_user_test' => [
-        'enabled' => TRUE,
+        'example' => TRUE,
         'negate' => TRUE,
         'id' => 'oe_authentication_user_test',
       ],
@@ -99,7 +99,7 @@ class SettingsFormTest extends BrowserTestBase {
     $config = \Drupal::config(AuthenticationSettingsForm::CONFIG_NAME);
     $this->assertEquals([
       'oe_authentication_user_test' => [
-        'enabled' => TRUE,
+        'example' => TRUE,
         'negate' => TRUE,
         'id' => 'oe_authentication_user_test',
       ],
@@ -114,7 +114,7 @@ class SettingsFormTest extends BrowserTestBase {
 
     // Check that the configuration is loaded back correctly.
     $this->drupalGet('/admin/config/system/oe_authentication');
-    $assert_session->checkboxChecked('Enabled', $test_condition_wrapper);
+    $assert_session->checkboxChecked('Example configuration option', $test_condition_wrapper);
     $assert_session->checkboxChecked('Negate', $test_condition_wrapper);
     $assert_session->checkboxChecked('Authenticated user', $user_role_condition_wrapper);
     $assert_session->checkboxNotChecked('Negate', $user_role_condition_wrapper);

--- a/tests/Functional/TwoFactorAuthenticationTest.php
+++ b/tests/Functional/TwoFactorAuthenticationTest.php
@@ -248,10 +248,13 @@ class TwoFactorAuthenticationTest extends BrowserTestBase {
    */
   protected function drupalLogout(): void {
     // Compared to the parent method, we don't run assertions on the user form
-    // being loaded in the page.
-    $this->drupalGet(Url::fromRoute('user.logout.confirm'));
+    // being loaded in the page. We instead check for a login link.
+    $destination = Url::fromRoute('user.page')->toString();
+    $this->drupalGet(Url::fromRoute('user.logout.confirm', options: ['query' => ['destination' => $destination]]));
     $assert_session = $this->assertSession();
     $assert_session->buttonExists('Log out')->press();
+    $this->assertUserNotLoggedIn();
+    $this->drupalResetSession();
   }
 
 }

--- a/tests/Functional/TwoFactorAuthenticationTest.php
+++ b/tests/Functional/TwoFactorAuthenticationTest.php
@@ -239,13 +239,16 @@ class TwoFactorAuthenticationTest extends BrowserTestBase {
    */
   protected function casLogin(string $email, string $password, array $query = []): void {
     $this->drupalGet(Url::fromRoute('cas.login', [], ['query' => $query]));
+    // The submit text is different from the default.
     $this->submitForm(['email' => $email, 'password' => $password], 'Login!');
   }
 
   /**
-   * Overrides the default logout method.
+   * {@inheritdoc}
    */
   protected function drupalLogout(): void {
+    // Compared to the parent method, we don't run assertions on the user form
+    // being loaded in the page.
     $this->drupalGet(Url::fromRoute('user.logout.confirm'));
     $assert_session = $this->assertSession();
     $assert_session->buttonExists('Log out')->press();

--- a/tests/Functional/TwoFactorAuthenticationTest.php
+++ b/tests/Functional/TwoFactorAuthenticationTest.php
@@ -1,0 +1,255 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\oe_authentication\Functional;
+
+use Drupal\Core\Url;
+use Drupal\Tests\BrowserTestBase;
+use Drupal\Tests\cas\Traits\CasTestTrait;
+use Drupal\user\Entity\Role;
+
+/**
+ * Tests two-factor authentication.
+ */
+class TwoFactorAuthenticationTest extends BrowserTestBase {
+
+  use CasTestTrait;
+
+  /**
+   * {@inheritdoc}
+   */
+  protected $defaultTheme = 'stark';
+
+  /**
+   * {@inheritdoc}
+   */
+  protected static $modules = [
+    'block',
+    'cas_mock_server',
+    'oe_authentication_eulogin_mock',
+    'oe_authentication_test',
+  ];
+
+  /**
+   * Tests the 2FA conditions.
+   */
+  public function testTwoFactorAuthenticationConditions(): void {
+    // Set 2FA to be required, but without any conditions.
+    $config = \Drupal::configFactory()->getEditable('oe_authentication.settings');
+    $config->set('force_2fa', TRUE)->save();
+    // Place the login block.
+    $this->placeBlock('system_menu_block:account');
+
+    // Create roles to use in the user role condition later.
+    $role_one = Role::create([
+      'id' => $this->randomMachineName(),
+      'label' => $this->randomMachineName(),
+    ]);
+    $role_one->save();
+    $role_two = Role::create([
+      'id' => $this->randomMachineName(),
+      'label' => $this->randomMachineName(),
+    ]);
+    $role_two->save();
+
+    // Create a CAS user that doesn't use 2FA when authenticating.
+    $basic_user = $this->createUser(name: 'basic_user');
+    $this->createCasUser('basic_user', 'basic_user@example.com', 'pwd1', [
+      'authenticationLevel' => 'BASIC',
+    ], $basic_user);
+
+    // Add other two users that use MEDIUM and HIGH 2FA methods.
+    $medium_user = $this->createUser(name: 'medium_user');
+    $this->createCasUser('medium_user', 'medium_user@example.com', 'pwd2', [
+      'authenticationLevel' => 'MEDIUM',
+    ], $medium_user);
+    $high_user = $this->createUser(name: 'high_user');
+    $this->createCasUser('high_user', 'high_user@example.com', 'pwd3', [
+      'authenticationLevel' => 'HIGH',
+    ], $high_user);
+
+    // Create two more users with basic authentication, each one with a
+    // different role.
+    $role_one_user = $this->createUser(name: 'role_one_user', values: [
+      'roles' => [$role_one->id()],
+    ]);
+    // This user has no authenticationLevel specified. It should be treated as
+    // BASIC level.
+    $this->createCasUser('role_one_user', 'role_one_user@example.com', 'pwd4', [], $role_one_user);
+    $role_two_user = $this->createUser(name: 'role_two_user', values: [
+      'roles' => [$role_two->id()],
+    ]);
+    $this->createCasUser('role_two_user', 'role_two_user@example.com', 'pwd5', [
+      'authenticationLevel' => 'BASIC',
+    ], $role_two_user);
+
+    // Create also a user with MEDIUM level and a role matching the condition
+    // below.
+    $medium_with_role_user = $this->createUser(name: 'medium_with_role_user', values: [
+      'roles' => [$role_one->id()],
+    ]);
+    $this->createCasUser('medium_with_role_user', 'medium_with_role_user@example.com', 'pwd6', [
+      'authenticationLevel' => 'MEDIUM',
+    ], $medium_with_role_user);
+
+    // Since no conditions are specified, users with 2FA can log in, while users
+    // without are bounced, as 2FA is mandatory.
+    $this->casLogin('basic_user@example.com', 'pwd1');
+    $assert_session = $this->assertSession();
+    $assert_session->statusMessageContains('You are required to log in using a two-factor authentication method.', 'error');
+    $this->casLogin('medium_user@example.com', 'pwd2');
+    $this->assertUserLoggedIn();
+    $this->drupalLogout();
+    $this->casLogin('high_user@example.com', 'pwd3');
+    $this->assertUserLoggedIn();
+    $this->drupalLogout();
+    // Check that when the authenticationLevel parameter is missing, it falls
+    // back to BASIC level.
+    $this->casLogin('role_one_user@example.com', 'pwd4');
+    $assert_session->statusMessageContains('You are required to log in using a two-factor authentication method.', 'error');
+
+    // Enable the conditions to allow to log in given a specific role.
+    $config->set('2fa_conditions', [
+      'user_role' => [
+        'id' => 'user_role',
+        'negate' => FALSE,
+        'roles' => [
+          $role_one->id() => $role_one->id(),
+        ],
+      ],
+    ])->save();
+
+    // The user account that matches the condition above is required to log in
+    // with a 2FA method.
+    $this->casLogin('role_one_user@example.com', 'pwd4');
+    $assert_session->statusMessageContains('You are required to log in using a two-factor authentication method.', 'error');
+    // Users that used a 2FA authentication method can always log in.
+    $this->casLogin('medium_user@example.com', 'pwd2');
+    $this->assertUserLoggedIn();
+    $this->drupalLogout();
+    $this->casLogin('high_user@example.com', 'pwd3');
+    $this->assertUserLoggedIn();
+    $this->drupalLogout();
+    // Test that conditions are ignored as long as the user is using a 2FA.
+    $this->casLogin('medium_with_role_user@example.com', 'pwd6');
+    $this->assertUserLoggedIn();
+    $this->drupalLogout();
+    // Users that use a non-2FA authentication method and do not match the
+    // conditions, are free to log in.
+    $this->casLogin('basic_user@example.com', 'pwd1');
+    $this->assertUserLoggedIn();
+    $this->drupalLogout();
+    $this->casLogin('role_two_user@example.com', 'pwd5');
+    $this->assertUserLoggedIn();
+    $this->drupalLogout();
+
+    // Enable a second condition.
+    $config->set('2fa_conditions', [
+      'oe_authentication_user_test' => [
+        'example' => TRUE,
+        'negate' => FALSE,
+        'id' => 'oe_authentication_user_test',
+      ],
+      'user_role' => [
+        'id' => 'user_role',
+        'negate' => FALSE,
+        'roles' => [
+          $role_one->id() => $role_one->id(),
+        ],
+      ],
+    ])->save();
+
+    // Set a user to be required to use 2FA.
+    \Drupal::state()->set('oe_authentication_user_test.account_name', 'role_two_user');
+    // Test that users that match at least one condition are required to use
+    // 2FA.
+    $this->casLogin('role_one_user@example.com', 'pwd4');
+    $assert_session->statusMessageContains('You are required to log in using a two-factor authentication method.', 'error');
+    $this->casLogin('role_two_user@example.com', 'pwd5');
+    $assert_session->statusMessageContains('You are required to log in using a two-factor authentication method.', 'error');
+    // Users that use a non-2FA authentication method and do not match the
+    // conditions, are free to log in.
+    $this->casLogin('basic_user@example.com', 'pwd1');
+    $this->assertUserLoggedIn();
+    $this->drupalLogout();
+    // Users that used a 2FA authentication method can always log in.
+    $this->casLogin('medium_user@example.com', 'pwd2');
+    $this->assertUserLoggedIn();
+    $this->drupalLogout();
+    $this->casLogin('high_user@example.com', 'pwd3');
+    $this->assertUserLoggedIn();
+    $this->drupalLogout();
+    $this->casLogin('medium_with_role_user@example.com', 'pwd6');
+    $this->assertUserLoggedIn();
+    $this->drupalLogout();
+
+    // Check that plugins are executed correctly, taking into account also
+    // the negate option.
+    $config->set('2fa_conditions', [
+      'oe_authentication_user_test' => [
+        'example' => TRUE,
+        'negate' => TRUE,
+        'id' => 'oe_authentication_user_test',
+      ],
+      'user_role' => [
+        'id' => 'user_role',
+        'negate' => FALSE,
+        'roles' => [
+          $role_one->id() => $role_one->id(),
+        ],
+      ],
+    ])->save();
+
+    $this->casLogin('role_one_user@example.com', 'pwd4');
+    $assert_session->statusMessageContains('You are required to log in using a two-factor authentication method.', 'error');
+    $this->casLogin('role_two_user@example.com', 'pwd5');
+    $this->assertUserLoggedIn();
+    $this->drupalLogout();
+    $this->casLogin('basic_user@example.com', 'pwd1');
+    $assert_session->statusMessageContains('You are required to log in using a two-factor authentication method.', 'error');
+  }
+
+  /**
+   * Tests that any exception thrown during condition evaluation is caught.
+   */
+  public function testConditionException(): void {
+    $config = \Drupal::configFactory()->getEditable('oe_authentication.settings');
+    $config
+      ->set('force_2fa', TRUE)
+      ->set('2fa_conditions', [
+        'oe_authentication_user_test' => [
+          'example' => TRUE,
+          'negate' => FALSE,
+          'id' => 'oe_authentication_user_test',
+        ],
+      ])
+      ->save();
+
+    \Drupal::state()->set('oe_authentication_user_test.crash_me', TRUE);
+    $basic_user = $this->createUser(name: 'basic_user');
+    $this->createCasUser('basic_user', 'basic_user@example.com', 'pwd1', [
+      'authenticationLevel' => 'BASIC',
+    ], $basic_user);
+    $this->casLogin('basic_user@example.com', 'pwd1');
+    $this->assertSession()->statusMessageContains('There was a problem validating your login, please contact a site administrator.', 'error');
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function casLogin(string $email, string $password, array $query = []): void {
+    $this->drupalGet(Url::fromRoute('cas.login', [], ['query' => $query]));
+    $this->submitForm(['email' => $email, 'password' => $password], 'Login!');
+  }
+
+  /**
+   * Overrides the default logout method.
+   */
+  protected function drupalLogout(): void {
+    $this->drupalGet(Url::fromRoute('user.logout.confirm'));
+    $assert_session = $this->assertSession();
+    $assert_session->buttonExists('Log out')->press();
+  }
+
+}

--- a/tests/modules/oe_authentication_test/config/schema/oe_authentication_test.schema.yml
+++ b/tests/modules/oe_authentication_test/config/schema/oe_authentication_test.schema.yml
@@ -1,6 +1,6 @@
 condition.plugin.oe_authentication_user_test:
   type: condition.plugin
   mapping:
-    enabled:
+    example:
       type: boolean
-      label: Enabled
+      label: An example configuration option.

--- a/tests/modules/oe_authentication_test/src/Plugin/Condition/UserTestCondition.php
+++ b/tests/modules/oe_authentication_test/src/Plugin/Condition/UserTestCondition.php
@@ -33,7 +33,7 @@ class UserTestCondition extends ConditionPluginBase {
    */
   public function defaultConfiguration() {
     return [
-      'enabled' => FALSE,
+      'example' => FALSE,
     ] + parent::defaultConfiguration();
   }
 
@@ -48,17 +48,19 @@ class UserTestCondition extends ConditionPluginBase {
    * {@inheritdoc}
    */
   public function evaluate() {
-    return (bool) $this->configuration['enabled'];
+    return (bool) $this->configuration['example'];
   }
 
   /**
    * {@inheritdoc}
    */
   public function buildConfigurationForm(array $form, FormStateInterface $form_state) {
-    $form['enabled'] = [
+    // A configuration entry, used only to test the saving of condition
+    // configuration.
+    $form['example'] = [
       '#type' => 'checkbox',
-      '#title' => $this->t('Enabled'),
-      '#default_value' => $this->configuration['enabled'],
+      '#title' => $this->t('Example configuration option'),
+      '#default_value' => $this->configuration['example'],
     ];
 
     $form['invalid'] = [
@@ -84,7 +86,7 @@ class UserTestCondition extends ConditionPluginBase {
    * {@inheritdoc}
    */
   public function submitConfigurationForm(array &$form, FormStateInterface $form_state) {
-    $this->configuration['enabled'] = $form_state->getValue('enabled');
+    $this->configuration['example'] = $form_state->getValue('example');
 
     parent::submitConfigurationForm($form, $form_state);
   }


### PR DESCRIPTION
Fixes #204 .

Logic implemented in this PR (pseudocode):

```
if (force_2fa)
  force 2fa for all users, by sending the parameters to eulogin
elseif (no conditions enabled)
  don't force 2fa for any user
elseif (no conditions match for user)
  don't force 2fa for this user
else
  # (at least one condition matches for user)
  Require 2fa:
  Reject login attempt for this user, if 2fa was not used.
  User needs to actively choose a 2fa method in eulogin.
```