### PR TITLE
Issue #229: Missing "langcode" in oe_authentication.settings.

### DIFF
--- a/config/install/oe_authentication.settings.yml
+++ b/config/install/oe_authentication.settings.yml
@@ -1,3 +1,4 @@
+langcode: en
 protocol: 'eulogin'
 register_path: 'eim/external/register.cgi'
 validation_path: 'TicketValidationService'

--- a/oe_authentication.post_update.php
+++ b/oe_authentication.post_update.php
@@ -61,3 +61,12 @@ function oe_authentication_post_update_00006(): void {
     ->set('message_login_2fa_required', 'Your account is required to log in using a two-factor authentication method. Please <a href=":login">log in again via this link</a>.')
     ->save();
 }
+
+/**
+ * Add missing langcode.
+ */
+function oe_authentication_post_update_00007(): void {
+  \Drupal::configFactory()->getEditable('oe_authentication.settings')
+    ->set('langcode', 'en')
+    ->save();
+}


### PR DESCRIPTION
- Copy of #230 to let drone run.